### PR TITLE
Fix typo/misspell in javadocs

### DIFF
--- a/src/main/java/com/force/i18n/HumanLanguage.java
+++ b/src/main/java/com/force/i18n/HumanLanguage.java
@@ -22,7 +22,7 @@ import com.force.i18n.commons.text.DeferredStringBuilder;
  * 
  * Usually there is a mapping from the language field of a locale to one of these languages,
  * but due to regional variation, a company may want to use a full locale to represent the human
- * language, especially for variants in Spanish, Portugese, German, and Chinese.
+ * language, especially for variants in Spanish, Portuguese, German, and Chinese.
  * 
  * For the override html language, see this page: http://www.w3.org/International/articles/bcp47/
  * @author stamm

--- a/src/main/java/com/force/i18n/Renameable.java
+++ b/src/main/java/com/force/i18n/Renameable.java
@@ -49,7 +49,7 @@ public interface Renameable {
 
     /**
      * @param labelKey the label from the grammar files
-     * @return for the given labelKey, return the DB key that should be used to retreive it.
+     * @return for the given labelKey, return the DB key that should be used to retrieve it.
      * I.e., if labelKey is "Entity" and this is "Account", it should return "Account".
      */
     String getEntitySpecificDbLabelKey(String labelKey);

--- a/src/main/java/com/force/i18n/commons/util/collection/IntHashMap.java
+++ b/src/main/java/com/force/i18n/commons/util/collection/IntHashMap.java
@@ -28,7 +28,7 @@ import com.google.common.annotations.Beta;
  * disperses the elements properly among the buckets.  Iteration over
  * collection views requires time proportional to the "capacity" of the
  * <tt>IntHashMap</tt> instance (the number of buckets) plus its size (the number
- * of key-value mappings).  Thus, it's very important not to set the intial
+ * of key-value mappings).  Thus, it's very important not to set the initial
  * capacity too high (or the load factor too low) if iteration performance is
  * important.<p>
  *

--- a/src/main/java/com/force/i18n/commons/util/collection/IntHashSet.java
+++ b/src/main/java/com/force/i18n/commons/util/collection/IntHashSet.java
@@ -23,7 +23,7 @@ import com.google.common.annotations.Beta;
  * buckets.  Iterating over this set requires time proportional to the sum of
  * the <tt>IntHashSet</tt> instance's size (the number of elements) plus the
  * "capacity" of the backing <tt>IntHashMap</tt> instance (the number of
- * buckets).  Thus, it's very important not to set the intial capacity too
+ * buckets).  Thus, it's very important not to set the initial capacity too
  * high (or the load factor too low) if iteration performance is important.<p>
  *
  * <b>Note that this implementation is not synchronized.</b> If multiple

--- a/src/main/java/com/force/i18n/grammar/LanguageDictionary.java
+++ b/src/main/java/com/force/i18n/grammar/LanguageDictionary.java
@@ -425,7 +425,7 @@ public final class LanguageDictionary implements Serializable {
             } else  if (n.getGender() != gender // Validate that it's the same
                     || n.getStartsWith() != startsWith
                     || n.isStandardField() != isStandardField) {
-                // We go in here when a label file is overriden with another
+                // We go in here when a label file is overridden with another
                 // Ex: when processing Mexican Spanish over regular Spanish OR when using the label renderer
                 n.setGender(gender);
                 n.setStartsWith(startsWith);


### PR DESCRIPTION
While browsing the repository, I found several typo/misspell in javadocs. Check the fixes when you have time.