### PR TITLE
Change scm protocol to https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,10 +315,10 @@
   
   <scm>
     <connection>
-      scm:git:git://github.com/salesforce/grammaticus.git
+      scm:git:https://github.com/salesforce/grammaticus.git
     </connection>
     <developerConnection>
-      scm:git:ssh://github.com:salesforce/grammaticus.git
+      scm:git:https://github.com:salesforce/grammaticus.git
     </developerConnection>
     <url>
       https://github.com/salesforce/grammaticus.git


### PR DESCRIPTION
github actions requires https when doing the prepare and blocks ssh.
@manodj-sfdc @BoYang-SFDC 