### PR TITLE
Add in Punjabi and Hmong platform support

### DIFF
--- a/src/main/java/com/force/i18n/DefaultHumanLanguageImpl.java
+++ b/src/main/java/com/force/i18n/DefaultHumanLanguageImpl.java
@@ -7,7 +7,13 @@
 
 package com.force.i18n;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -96,6 +102,7 @@ enum DefaultHumanLanguageImpl implements HumanLanguage {
     KANNADA(new Locale("kn"), LanguageType.PLATFORM, 220.0),
     MARATHI(new Locale("mr"), LanguageType.PLATFORM, 220.0),
     GUJARATI(new Locale("gu"), LanguageType.PLATFORM, 220.0),
+    PUNJABI(new Locale("pa"), LanguageType.PLATFORM, 238.0),
 
     MAORI(new Locale("mi"), LanguageType.PLATFORM, 220.0),
     BURMESE(new Locale("my"), LanguageType.PLATFORM, 220.0),
@@ -112,7 +119,9 @@ enum DefaultHumanLanguageImpl implements HumanLanguage {
 
     GREENLANDIC(new Locale("kl"), LanguageType.PLATFORM, 234.0), //Greenlandic -- no grammar support in 234
     YIDDISH(new Locale("ji"), LanguageType.PLATFORM, "yi", 236.0),  // Java screwup with iso code.
+    HMONG(new Locale("hmn"), LanguageType.PLATFORM, 238.0),
 
+    
     // Sample use of variants for testing
     ARABIC_DZ(new Locale("ar", "DZ"), LanguageType.PLATFORM, 194.0), //Arabic Algerian
     ENGLISH_AU(new Locale("en", "AU"), LanguageType.PLATFORM, 168.0),

--- a/src/main/java/com/force/i18n/LanguageConstants.java
+++ b/src/main/java/com/force/i18n/LanguageConstants.java
@@ -78,7 +78,7 @@ public final class LanguageConstants {
     public static final String MARATHI = "mr";
     public static final String GUJARATI = "gu";
     public static final String PUNJABI = "pa";
-    public static final String PUNJABI_WESTERN = "pnb";
+    public static final String PUNJABI_WESTERN = "pnb";  // aka pa_Arab
     public static final String MAORI = "mi";
     public static final String BURMESE = "my";
     public static final String PERSIAN = "fa";

--- a/src/main/java/com/force/i18n/LanguageConstants.java
+++ b/src/main/java/com/force/i18n/LanguageConstants.java
@@ -77,6 +77,7 @@ public final class LanguageConstants {
     public static final String MALAYALAM = "ml";
     public static final String MARATHI = "mr";
     public static final String GUJARATI = "gu";
+    public static final String PUNJABI = "pa";
     public static final String MAORI = "mi";
     public static final String BURMESE = "my";
     public static final String PERSIAN = "fa";
@@ -89,6 +90,7 @@ public final class LanguageConstants {
     public static final String AZERBAIJANI = "az";
     public static final String GREENLANDIC = "kl";
     public static final String YIDDISH = "ji"; // Fix java screwup
+    public static final String HMONG = "hmn";
     
     // platform languages
     public static final String SPANISH_MX = "es_MX"; //Spanish (Mexican), end-user lang prior to 190

--- a/src/main/java/com/force/i18n/LanguageConstants.java
+++ b/src/main/java/com/force/i18n/LanguageConstants.java
@@ -78,6 +78,7 @@ public final class LanguageConstants {
     public static final String MARATHI = "mr";
     public static final String GUJARATI = "gu";
     public static final String PUNJABI = "pa";
+    public static final String PUNJABI_WESTERN = "pnb";
     public static final String MAORI = "mi";
     public static final String BURMESE = "my";
     public static final String PERSIAN = "fa";

--- a/src/main/java/com/force/i18n/TextDirection.java
+++ b/src/main/java/com/force/i18n/TextDirection.java
@@ -122,6 +122,7 @@ public enum TextDirection {
         case "ckb":
         case "lrc":
         case "mzn":
+        case "pnb":
             return invertIfNotNormalDirection(RTL);
         default:
         }

--- a/src/main/java/com/force/i18n/grammar/impl/IndoAryanDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/IndoAryanDeclension.java
@@ -6,13 +6,33 @@
  */
 package com.force.i18n.grammar.impl;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
 import java.util.logging.Logger;
 
 import com.force.i18n.HumanLanguage;
-import com.force.i18n.grammar.*;
+import com.force.i18n.grammar.AbstractLanguageDeclension;
+import com.force.i18n.grammar.Adjective;
+import com.force.i18n.grammar.AdjectiveForm;
+import com.force.i18n.grammar.LanguageArticle;
+import com.force.i18n.grammar.LanguageCase;
+import com.force.i18n.grammar.LanguageDeclension;
+import com.force.i18n.grammar.LanguageGender;
+import com.force.i18n.grammar.LanguageNumber;
+import com.force.i18n.grammar.LanguagePosition;
+import com.force.i18n.grammar.LanguagePossessive;
+import com.force.i18n.grammar.LanguageStartsWith;
+import com.force.i18n.grammar.Noun;
 import com.force.i18n.grammar.Noun.NounType;
-import com.force.i18n.grammar.impl.ComplexGrammaticalForm.*;
+import com.force.i18n.grammar.NounForm;
+import com.force.i18n.grammar.impl.ComplexGrammaticalForm.ComplexAdjective;
+import com.force.i18n.grammar.impl.ComplexGrammaticalForm.ComplexAdjectiveForm;
+import com.force.i18n.grammar.impl.ComplexGrammaticalForm.ComplexNoun;
+import com.force.i18n.grammar.impl.ComplexGrammaticalForm.ComplexNounForm;
+import com.force.i18n.grammar.impl.ComplexGrammaticalForm.ModifierFormMap;
+import com.force.i18n.grammar.impl.ComplexGrammaticalForm.NounFormMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -269,6 +289,20 @@ abstract class IndoAryanDeclension extends AbstractLanguageDeclension {
         @Override
         public EnumSet<LanguageCase> getRequiredCases() {
             return EnumSet.of(LanguageCase.NOMINATIVE, LanguageCase.ACCUSATIVE, LanguageCase.INSTRUMENTAL, LanguageCase.DATIVE, LanguageCase.ABLATIVE, LanguageCase.GENITIVE, LanguageCase.LOCATIVE); 
+        }
+    }
+    
+    // https://en.wikipedia.org/wiki/Punjabi_grammar
+    // Nominitive = direct
+    // Accusative = oblique
+    static final class PunjabiDeclension extends IndoAryanDeclension {
+        public PunjabiDeclension(HumanLanguage language) {
+            super(language);
+        }
+        
+        @Override
+        public EnumSet<LanguageCase> getRequiredCases() {
+            return EnumSet.of(LanguageCase.NOMINATIVE, LanguageCase.ACCUSATIVE, LanguageCase.INSTRUMENTAL, LanguageCase.ABLATIVE, LanguageCase.VOCATIVE); 
         }
     }
 

--- a/src/main/java/com/force/i18n/grammar/impl/LanguageDeclensionFactory.java
+++ b/src/main/java/com/force/i18n/grammar/impl/LanguageDeclensionFactory.java
@@ -12,7 +12,9 @@ import static com.force.i18n.LanguageConstants.*;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.force.i18n.*;
+import com.force.i18n.HumanLanguage;
+import com.force.i18n.I18nJavaUtil;
+import com.force.i18n.LanguageProviderFactory;
 import com.force.i18n.grammar.LanguageDeclension;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -149,6 +151,8 @@ public enum LanguageDeclensionFactory {
             return new SimpleDeclension.SimpleDeclensionWithClassifiers(language);
         case VIETNAMESE:
             return new SimpleDeclension.VietnameseDeclension(language);
+        case HMONG:
+            return new SimpleDeclension.HmongDeclension(language);
         case THAI:
         case TAGALOG:
         case AFRIKAANS:
@@ -246,6 +250,8 @@ public enum LanguageDeclensionFactory {
             return new IndoAryanDeclension.GujaratiDeclension(language);
         case MARATHI:
             return new IndoAryanDeclension.MarathiDeclension(language);
+        case PUNJABI:
+            return new IndoAryanDeclension.PunjabiDeclension(language);
         // Languages too complex to support *EVER*.  Included with ans
         case IRISH:    // Lenition
             return new UnsupportedLanguageDeclension.IrishDeclension(language);

--- a/src/main/java/com/force/i18n/grammar/impl/LanguageDeclensionFactory.java
+++ b/src/main/java/com/force/i18n/grammar/impl/LanguageDeclensionFactory.java
@@ -251,6 +251,7 @@ public enum LanguageDeclensionFactory {
         case MARATHI:
             return new IndoAryanDeclension.MarathiDeclension(language);
         case PUNJABI:
+        case PUNJABI_WESTERN:
             return new IndoAryanDeclension.PunjabiDeclension(language);
         // Languages too complex to support *EVER*.  Included with ans
         case IRISH:    // Lenition

--- a/src/main/java/com/force/i18n/grammar/impl/SimpleDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/SimpleDeclension.java
@@ -10,13 +10,29 @@ package com.force.i18n.grammar.impl;
 import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 
 import com.force.i18n.HumanLanguage;
 import com.force.i18n.LanguageConstants;
-import com.force.i18n.grammar.*;
+import com.force.i18n.grammar.AbstractLanguageDeclension;
+import com.force.i18n.grammar.Adjective;
+import com.force.i18n.grammar.AdjectiveForm;
+import com.force.i18n.grammar.LanguageArticle;
+import com.force.i18n.grammar.LanguageCase;
+import com.force.i18n.grammar.LanguageDeclension;
+import com.force.i18n.grammar.LanguageGender;
+import com.force.i18n.grammar.LanguageNumber;
+import com.force.i18n.grammar.LanguagePosition;
+import com.force.i18n.grammar.LanguagePossessive;
+import com.force.i18n.grammar.LanguageStartsWith;
+import com.force.i18n.grammar.Noun;
 import com.force.i18n.grammar.Noun.NounType;
+import com.force.i18n.grammar.NounForm;
 import com.google.common.collect.ImmutableList;
 /**
  * An implementation of declension of a language that doesn't use different forms for nouns.
@@ -274,6 +290,24 @@ class SimpleDeclension extends AbstractLanguageDeclension {
         }
 
     }
+    
+    /**
+     * Hmong declension that is similar to SimpleDeclention, but has capitalization and classifiers.
+     *
+     * @author stamm
+     * @since 1.3
+     */
+    static class HmongDeclension extends SimpleDeclensionWithClassifiers {
+
+        public HmongDeclension(HumanLanguage language) {
+            super(language);
+        }
+
+        @Override
+        public boolean hasCapitalization() {
+            return true;
+        }
+    }
 
     static String getDefaultClassifier(HumanLanguage language) {
         switch (language.getLocale().getLanguage()) {
@@ -297,6 +331,8 @@ class SimpleDeclension extends AbstractLanguageDeclension {
         case LanguageConstants.MALAY:
         case LanguageConstants.INDONESIAN:
             return "buah";  // Often found in compound with 'se-'
+        case LanguageConstants.HMONG:
+            return "tus";  // tus: generic animate, so not super generic either
         }
         return "";
     }

--- a/src/main/java/com/force/i18n/grammar/offline/PluralRulesJsImpl.java
+++ b/src/main/java/com/force/i18n/grammar/offline/PluralRulesJsImpl.java
@@ -21,7 +21,7 @@ import java.util.Locale;
 public class PluralRulesJsImpl {
     private final static String NO_DIFF = "function (n) {return 'other';}";
     private final static String ONE = "function (n) {return n == 1 || n == -1 ? 'one' : 'other';}";
-    //private final static String ONE_OR_ZERO = "function (n) {return n == 0 || n == 1 || n == -1 ? 'one' : 'other';}";
+    private final static String ONE_OR_ZERO = "function (n) {return n == 0 || n == 1 || n == -1 ? 'one' : 'other';}";
     private final static String EXACT_ONE = "function (n) {return n == 1 && !String(n).split('.')[1] ? 'one' : 'other';}";
 
     public static String getSelectFunction(Locale locale) {
@@ -97,6 +97,7 @@ public class PluralRulesJsImpl {
 
              case HUNGARIAN:return ONE;
              case ARMENIAN:return "function hy(n) {return n >= 0 && n < 2 ? 'one' : 'other';}";
+             case PUNJABI:return ONE_OR_ZERO;
              //case "id":return noDiff;
              //case "ig":return noDiff;
              case ICELANDIC:return "function is(n) {"+

--- a/src/main/java/com/force/i18n/grammar/offline/PluralRulesJsImpl.java
+++ b/src/main/java/com/force/i18n/grammar/offline/PluralRulesJsImpl.java
@@ -97,6 +97,7 @@ public class PluralRulesJsImpl {
 
              case HUNGARIAN:return ONE;
              case ARMENIAN:return "function hy(n) {return n >= 0 && n < 2 ? 'one' : 'other';}";
+             case PUNJABI_WESTERN:
              case PUNJABI:return ONE_OR_ZERO;
              //case "id":return noDiff;
              //case "ig":return noDiff;

--- a/src/main/resources/com/force/i18n/grammar/public_i18n.xml
+++ b/src/main/resources/com/force/i18n/grammar/public_i18n.xml
@@ -85,6 +85,8 @@
         <param name="ml">മലയാളം</param>
         <param name="gu">ગુજરાતી</param>
         <param name="mr">मराठी</param>
+        <param name="pa">ਪੰਜਾਬੀ</param>
+        <param name="pnb">پنجابی</param>
         <param name="sw">Kiswahili</param>
         <param name="af">Afrikaans</param>
         <param name="zu">IsiZulu</param>
@@ -94,6 +96,7 @@
         <param name="sm">Gagana Sāmoa</param>
         <param name="ht">Kreyòl ayisyen</param>
         <param name="yi">יידיש</param>
+        <param name="hmn">Hmoob</param>
         
         <param name="ar_DZ">(العربية (الجزائر</param>
         <param name="ar_BH">(العربية (‏البحرين</param>


### PR DESCRIPTION
Hmong is similar to Vietnamese, but without plurals.  Using the generic "hmn"
Punjabi is IndoAryan with 5 cases.  Has one or zero pluralRules