### PR TITLE
Fixed BaseLocalizer#getInputDateTimeFormat(int) returns wrong cached result

### DIFF
--- a/src/main/java/com/force/i18n/BaseLocalizer.java
+++ b/src/main/java/com/force/i18n/BaseLocalizer.java
@@ -876,20 +876,17 @@ public class BaseLocalizer {
      * @return a DateFormat based on localizer's locale and time zone
      */
     public DateFormat getInputDateTimeFormat(int style) {
-        if (this.dateTimeFormat == null) {
-            switch (style) {
-                case DateFormat.SHORT:
-                    return getInputDateTimeFormat();
-                case DateFormat.MEDIUM:
-                    return getInputMediumDateTimeFormat();
-                case DateFormat.LONG:
-                    //Uses short date and and long time formats
-                    return getInputLongDateTimeFormat();
-                default:
-                    return getInputDateTimeFormat();
-            }
+        switch (style) {
+        case DateFormat.SHORT:
+            return getInputDateTimeFormat();
+        case DateFormat.MEDIUM:
+            return getInputMediumDateTimeFormat();
+        case DateFormat.LONG:
+            //Uses short date and and long time formats
+            return getInputLongDateTimeFormat();
+        default:
+            return getInputDateTimeFormat();
         }
-        return this.dateTimeFormat;
     }
 
     /**


### PR DESCRIPTION
`BaseLocalizer#getInputDateTimeFormat(int)` tests `this.dateTimeFormat` and returns the value if it's not `null`. This looks strange because:
1. this is for "input". `this.dateTimeFormat` is used by `getDateTimeFormat()` instead. 
2. each method in `switch` statement use its own member variable (e.g. `getInputDateTimeFormat()` reuses `this.inputDateTimeFormat`). 
3. current implementation returns different result. for example, `getInputDateTimeFormat(LONG)` is different from  `getInputLongDateTimeFormat()` because the first one returns the same result of `getDateTimeFormat()`