### PR TITLE
Update Github Actions file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
     branches:
     - main
-    - 'releases/**'    
+    - 'releases/**'
 
 jobs:
   build:
@@ -20,19 +20,19 @@ jobs:
       matrix:
         java: [ '11' ]
     steps:
-    - uses: actions/checkout@v2    
+    - uses: actions/checkout@v3
     - name: Set up JDK
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: ${{ matrix.java }}
         distribution: 'zulu'
         cache: maven
     - name: Cache local Maven repository
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-maven-
     - name: Build with Maven
       run: mvn -P clean verify -B
-  
+

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -20,9 +20,9 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Apache Maven Central
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with: # running setup-java again overwrites the settings.xml
         distribution: 'zulu'
         java-version: '11'
@@ -42,7 +42,7 @@ jobs:
           git_tag_gpgsign: true
           git_push_gpgsign: false
     - name: Cache local Maven repository
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -50,8 +50,9 @@ jobs:
     - name: Prepare Release
       id: release
       run: >
-          mvn -V -gs $GITHUB_WORKSPACE/generated-settings/settings.xml -B -P sonatype-staging,release -e release:clean release:prepare && 
-          echo "::set-output name=RELEASED_VERSION::$(grep scm.tag= release.properties | cut -d'=' -f2 | cut -c2-)"
+          mvn -V -gs $GITHUB_WORKSPACE/generated-settings/settings.xml -B -P sonatype-staging,release -e release:clean release:prepare &&
+          echo "RELEASED_NAME=G$(grep scm.tag= release.properties | cut -d'=' -f2 | cut -c2-)" >> $GITHUB_OUTPUT
+          echo "RELEASED_VERSION=$(grep scm.tag= release.properties | cut -d'=' -f2 | cut -c13-)" >> $GITHUB_OUTPUT
       env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USER }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
@@ -71,7 +72,7 @@ jobs:
       uses: actions/create-release@v1
       with:
           tag_name: v${{ steps.release.outputs.RELEASED_VERSION }}
-          release_name: ${{ steps.release.outputs.RELEASED_VERSION }}
+          release_name: ${{ steps.release.outputs.RELEASED_NAME }}
           body: ${{ github.event.inputs.release-body }}
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 release.properties
 *~
 generated-settings*
+.vscode/
+*.iml


### PR DESCRIPTION
Update actions to comply with following:
- update version to run w/ node 16 (https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
- fix deprecated commands (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)