### PR TITLE
More serialization friendly fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
+
   <groupId>com.salesforce.grammaticus</groupId>
   <artifactId>grammaticus</artifactId>
   <version>1.2.6-SNAPSHOT</version>
   <packaging>jar</packaging>
-  
+
   <name>Grammaticus</name>
   <description>Localization Framework that allows grammatically correct renaming of nouns</description>
   <url>https://github.com/salesforce/grammaticus</url>
@@ -13,14 +13,14 @@
       <name>Salesforce</name>
       <url>http://www.salesforce.com</url>
   </organization>
-  
+
   <licenses>
       <license>
           <name>BSD 3-Clause</name>
           <url>file://${basedir}/LICENSE.txt</url>
       </license>
   </licenses>
-  
+
   <developers>
     <developer>
         <name>Yoshiyuki Oikawa</name>
@@ -45,9 +45,9 @@
         </roles>
         <email>bo.yang@salesforce.com</email>
         <organization>Salesforce</organization>
-    </developer>        
+    </developer>
   </developers>
-  
+
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
@@ -55,16 +55,15 @@
     <icu4j.version>69.1</icu4j.version>
     <icu4j-localespi.version>69.1</icu4j-localespi.version>
     <picocli.version>4.1.4</picocli.version>
-    <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
   </properties>
-  
+
   <profiles>
     <profile>
       <!-- This profile uploads to sonatype (which is used to get artifacts into maven central) -->
       <id>sonatype-staging</id>
       <activation>
         <activeByDefault>true</activeByDefault>
-      </activation> 
+      </activation>
       <distributionManagement>
         <snapshotRepository>
           <id>ossrh</id>
@@ -79,6 +78,14 @@
       <build>
         <plugins>
           <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>3.0.0-M8</version>
+            <configuration>
+              <!-- suppress all loggings for unit test -->
+              <argLine>@{argLine} -Djava.util.logging.config.file=src/test/resources/logging.properties</argLine>
+            </configuration>
+          </plugin>
+          <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
             <version>1.6.7</version>
@@ -89,10 +96,10 @@
               <autoReleaseAfterClose>true</autoReleaseAfterClose>
             </configuration>
           </plugin>
-        </plugins> 
+        </plugins>
       </build>
     </profile>
-    
+
     <profile>
       <id>release</id>
       <build>
@@ -124,7 +131,7 @@
                 </execution>
             </executions>
           </plugin>
-          
+
           <!-- GPG Signed -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -146,10 +153,10 @@
                 </goals>
               </execution>
             </executions>
-	  </plugin>       
+	  </plugin>
         </plugins>
       </build>
-    </profile>      
+    </profile>
   </profiles>
 
   <build>
@@ -165,7 +172,7 @@
         </excludes>
       </resource>
     </resources>
-    
+
     <plugins>
       <!-- always build source jars -->
       <plugin>
@@ -181,7 +188,7 @@
           </execution>
         </executions>
       </plugin>
-      
+
       <!-- Code coverage -->
       <plugin>
         <groupId>org.jacoco</groupId>
@@ -201,9 +208,9 @@
               </goals>
           </execution>
         </executions>
-      </plugin> 
-	  
-	  <plugin>
+      </plugin>
+
+      <plugin>
         <!-- create VersionInfo class -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>templating-maven-plugin</artifactId>
@@ -217,29 +224,28 @@
           </execution>
         </executions>
       </plugin>
-	  
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <version>2.8.2</version>
-	  </plugin>
-	   
-	   <!-- Maven Release plugin -->
-	   <plugin>
-	    <groupId>org.apache.maven.plugins</groupId>
-	    <artifactId>maven-release-plugin</artifactId>
-	    <version>2.5.3</version>
-	    <configuration>
-	      <autoVersionSubmodules>true</autoVersionSubmodules>
-	      <useReleaseProfile>false</useReleaseProfile>
-	      <releaseProfiles>release</releaseProfiles>
-	      <goals>deploy</goals>
-	    </configuration>
-	  </plugin>
+      </plugin>
 
+      <!-- Maven Release plugin -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>2.5.3</version>
+        <configuration>
+          <autoVersionSubmodules>true</autoVersionSubmodules>
+          <useReleaseProfile>false</useReleaseProfile>
+          <releaseProfiles>release</releaseProfiles>
+          <goals>deploy</goals>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
-  
+
   <reporting>
     <plugins>
       <plugin>
@@ -262,14 +268,14 @@
       </plugin>
     </plugins>
   </reporting>
-  
-  
+
+
   <dependencies>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>30.1.1-jre</version>
-    </dependency> 
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>
@@ -283,7 +289,7 @@
       <artifactId>icu4j</artifactId>
       <version>${icu4j.version}</version>
     </dependency>
-    
+
     <dependency>
       <groupId>com.ibm.icu</groupId>
       <artifactId>icu4j-localespi</artifactId>
@@ -310,7 +316,7 @@
       <artifactId>js</artifactId>
       <version>20.3.0</version>
       <scope>test</scope>
-    </dependency>  
+    </dependency>
     <dependency>
       <groupId>org.graalvm.js</groupId>
       <artifactId>js-scriptengine</artifactId>
@@ -319,7 +325,7 @@
     </dependency>
 
   </dependencies>
-  
+
   <scm>
     <connection>
       scm:git:https://github.com/salesforce/grammaticus.git

--- a/src/main/java/com/force/i18n/LabelSetDescriptorImpl.java
+++ b/src/main/java/com/force/i18n/LabelSetDescriptorImpl.java
@@ -131,7 +131,7 @@ public class LabelSetDescriptorImpl implements GrammaticalLabelSetDescriptor {
     @Override
     public int hashCode() {
         // ignoring setName and dictionary name
-        return Objects.hash(language, basename, rootDirectory.toExternalForm());
+        return Objects.hash(language, setName, basename, dictionaryName, rootDirectory.toExternalForm());
     }
 
     @Override
@@ -145,7 +145,9 @@ public class LabelSetDescriptorImpl implements GrammaticalLabelSetDescriptor {
         // ignoring setName and dictionary name
         LabelSetDescriptorImpl other = (LabelSetDescriptorImpl)obj;
         return language.equals(other.language)  // language can't be null
+                && Objects.equals(this.setName, other.setName)
                 && Objects.equals(this.basename, other.basename)
+                && Objects.equals(this.dictionaryName, other.dictionaryName)
                 && rootDirectory.toExternalForm().equals(other.rootDirectory.toExternalForm());
     }
 

--- a/src/main/java/com/force/i18n/commons/util/collection/MapSerializer.java
+++ b/src/main/java/com/force/i18n/commons/util/collection/MapSerializer.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2023 Salesforce, Inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.force.i18n.commons.util.collection;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableSortedMap;
+
+/**
+ * Proxy of {@code Map<Object, Object>} that "uniquefy" key and value.
+ *
+ * @author yoikawa
+ */
+public abstract class MapSerializer<K extends Serializable & Comparable<?>, V extends Serializable> implements Serializable {
+
+    protected transient Map<K, V> map;
+
+    protected final Object keys;
+    protected final Object values;
+
+    /**
+     * @param map a map to wrap
+     * @throws NullPointerException when {@code map} is {@code null}
+     */
+    protected MapSerializer(Map<K, V> map) {
+        if (map == null) throw new NullPointerException();
+        this.map = map;
+
+        // go classic way
+        Object[] k = new Object[map.size()];
+        Object[] v = new Object[map.size()];
+
+        int i = 0;
+        for (Map.Entry<K, V> e : map.entrySet()) {
+            k[i] = internKey(e.getKey());
+            v[i] = internValue(e.getValue());
+            ++i;
+        }
+        this.keys = k;
+        this.values = v;
+    }
+
+    protected abstract K internKey(K key);
+
+    // override this if you need "deep" uniquely for values too
+    protected V internValue(V value) { return value; }
+
+    @SuppressWarnings("unchecked")
+    protected Object readResolve() {
+        Object[] k = (Object[])this.keys;
+        Object[] v = (Object[])this.values;
+
+        ImmutableSortedMap.Builder<K, V> builder = ImmutableSortedMap.naturalOrder();
+        for (int i = 0; i < k.length; i++) {
+            builder.put(internKey((K)k[i]), internValue((V)v[i]));
+        }
+        this.map = builder.build();
+        return this;
+    }
+}

--- a/src/main/java/com/force/i18n/grammar/AbstractLanguageDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/AbstractLanguageDeclension.java
@@ -9,21 +9,13 @@ package com.force.i18n.grammar;
 
 import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
 
-import java.io.IOException;
+import java.io.*;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.logging.Logger;
 
-import com.force.i18n.HumanLanguage;
-import com.force.i18n.LanguagePluralRules;
-import com.force.i18n.LanguageProviderFactory;
+import com.force.i18n.*;
 import com.force.i18n.grammar.Noun.NounType;
 import com.force.i18n.grammar.offline.PluralRulesJsImpl;
 
@@ -37,31 +29,16 @@ import com.force.i18n.grammar.offline.PluralRulesJsImpl;
  * @author stamm
  */
 public abstract class AbstractLanguageDeclension implements LanguageDeclension {
-	private final HumanLanguage language;
+    private final HumanLanguage language;
 
-	public AbstractLanguageDeclension(HumanLanguage language) {
-		this.language = language;
-	}
+    protected AbstractLanguageDeclension(HumanLanguage language) {
+        this.language = language;
+    }
 
     @Override
     public final HumanLanguage getLanguage() {
     	return this.language;
     }
-
-    @Override
-    public abstract List< ? extends NounForm> getAllNounForms();
-
-    @Override
-    public abstract Collection<? extends NounForm> getEntityForms();
-
-    @Override
-    public abstract Collection<? extends NounForm> getFieldForms();
-
-    @Override
-    public abstract Collection<? extends NounForm> getOtherForms();
-
-    @Override
-    public abstract List<? extends AdjectiveForm> getAdjectiveForms();
 
     @Override
     public List<? extends ArticleForm> getArticleForms() {
@@ -126,7 +103,6 @@ public abstract class AbstractLanguageDeclension implements LanguageDeclension {
     public boolean hasPossessive() {
         return false;  // Default to false because few languages have it
     }
-
 
     @Override
     public boolean hasPossessiveInAdjective() {
@@ -508,6 +484,7 @@ public abstract class AbstractLanguageDeclension implements LanguageDeclension {
     public static class SimpleAdjective extends Adjective {
         private static final long serialVersionUID = 1L;
         private static final Logger logger = Logger.getLogger(SimpleAdjective.class.getName());
+
         private String value;
 
         public SimpleAdjective(LanguageDeclension declension, String name) {
@@ -539,6 +516,11 @@ public abstract class AbstractLanguageDeclension implements LanguageDeclension {
             }
             return true;
         }
+
+        protected Object readResolve() {
+            this.value = intern(this.value);
+            return this;
+        }
     }
 
     /**
@@ -548,6 +530,7 @@ public abstract class AbstractLanguageDeclension implements LanguageDeclension {
     public static class SimpleAdjectiveWithStartsWith extends SimpleAdjective {
         private static final long serialVersionUID = 1L;
 
+        // no need to implement hashCode() and equals(Object)  superclass takes care this field too
         private final LanguageStartsWith startsWith;
 
         public SimpleAdjectiveWithStartsWith(LanguageDeclension declension, String name, LanguageStartsWith startsWith) {
@@ -678,6 +661,14 @@ public abstract class AbstractLanguageDeclension implements LanguageDeclension {
         public Noun clone() {
             SimplePluralNounWithGender noun = (SimplePluralNounWithGender) super.clone();
             return noun;
+        }
+
+        @Override
+        protected Object readResolve() {
+            super.readResolve();
+            this.singular = intern(this.singular);
+            this.plural = intern(this.plural);
+            return this;
         }
     }
 

--- a/src/main/java/com/force/i18n/grammar/Article.java
+++ b/src/main/java/com/force/i18n/grammar/Article.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -10,6 +10,7 @@ package com.force.i18n.grammar;
 import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -20,14 +21,12 @@ import com.google.common.collect.ImmutableSet;
  * @author stamm
  */
 public abstract class Article extends NounModifier {
-    /**
-	 * 
-	 */
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-	private static final Logger logger = Logger.getLogger(Article.class.getName());
+    private static final Logger logger = Logger.getLogger(Article.class.getName());
 
     private final LanguageArticle articleType;
+
     protected Article(ArticledDeclension declension, String name, LanguageArticle articleType) {
         super(declension, name);
         this.articleType = articleType;
@@ -41,7 +40,6 @@ public abstract class Article extends NounModifier {
     public LanguageArticle getArticleType() {
         return this.articleType;
     }
-
 
     /**
      * @return all the forms of the adjective
@@ -152,11 +150,26 @@ public abstract class Article extends NounModifier {
                         logger.info("###\tERROR: The article " + name + " has no obvious default for " + form + "form");
                     }
                 }
-                
+
                 setString(form, intern(s));
             }
         }
         return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), this.articleType);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (other instanceof Article) {
+            Article a = (Article)other;
+            return super.equals(a) && this.articleType == a.articleType;
+        }
+        return false;
     }
 
     @Override protected TermType getTermType() { return TermType.Article; }

--- a/src/main/java/com/force/i18n/grammar/ArticledDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/ArticledDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -37,12 +37,9 @@ public abstract class ArticledDeclension extends AbstractLanguageDeclension {
      * See EnglishNounForm for more info
      */
     public abstract static class LegacyArticledNoun extends Noun {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
 
-		protected LegacyArticledNoun(ArticledDeclension declension, String name, String pluralAlias, NounType type, String entityName, LanguageStartsWith startsWith, LanguageGender gender, String access, boolean isStandardField, boolean isCopiedFromDefault) {
+        protected LegacyArticledNoun(ArticledDeclension declension, String name, String pluralAlias, NounType type, String entityName, LanguageStartsWith startsWith, LanguageGender gender, String access, boolean isStandardField, boolean isCopiedFromDefault) {
             super(declension, name, pluralAlias, type, entityName, startsWith, gender, access, isStandardField, isCopiedFromDefault);
         }
 
@@ -114,12 +111,11 @@ public abstract class ArticledDeclension extends AbstractLanguageDeclension {
      * Represents a simple adjective with one inflection
      */
     public static class SimpleArticle extends Article {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private static final Logger logger = Logger.getLogger(SimpleArticle.class.getName());
+        private static final long serialVersionUID = 1L;
+        private static final Logger logger = Logger.getLogger(SimpleArticle.class.getName());
+
         private String value;
+
         public SimpleArticle(ArticledDeclension declension, String name, LanguageArticle articleType) {
             super(declension, name, articleType);
         }
@@ -143,6 +139,11 @@ public abstract class ArticledDeclension extends AbstractLanguageDeclension {
             }
             return true;
         }
+
+        protected Object readResolve() {
+            this.value = intern(this.value);
+            return this;
+        }
     }
 
     /**
@@ -150,11 +151,9 @@ public abstract class ArticledDeclension extends AbstractLanguageDeclension {
      * Pretty much the same as SimplePluarlNoun, but needing to extend LegacyArticledNoun to support articles
      */
     public static class SimpleArticledPluralNoun extends LegacyArticledNoun {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private static final Logger logger = Logger.getLogger(SimpleArticledPluralNoun.class.getName());
+        private static final long serialVersionUID = 1L;
+
+        private static final Logger logger = Logger.getLogger(SimpleArticledPluralNoun.class.getName());
         private String singular;
         private String plural;
 
@@ -218,6 +217,14 @@ public abstract class ArticledDeclension extends AbstractLanguageDeclension {
 
         @Override
         public void makeSkinny() {
+        }
+
+        @Override
+        protected Object readResolve() {
+            super.readResolve();
+            this.singular = intern(this.singular);
+            this.plural = intern(this.plural);
+            return this;
         }
     }
 }

--- a/src/main/java/com/force/i18n/grammar/GrammaticalForm.java
+++ b/src/main/java/com/force/i18n/grammar/GrammaticalForm.java
@@ -1,17 +1,19 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
 package com.force.i18n.grammar;
 
+import java.io.Serializable;
+
 /**
  * A base interface for all the grammatical forms.
  * @author stamm
  */
-public interface GrammaticalForm {
+public interface GrammaticalForm extends Serializable {
     /**
      * @return the number associated with this adjective form
      */
@@ -20,10 +22,10 @@ public interface GrammaticalForm {
      * @return the grammatical case associated with this adjective form
      */
     LanguageCase getCase();
-    
+
     /**
      * @return a HTML compatible screen that can be used to represent this grammatical
-     * form uniquely when compared to all other forms. 
+     * form uniquely when compared to all other forms.
      */
     String getKey();
 }

--- a/src/main/java/com/force/i18n/grammar/GrammaticalLabelSetFallbackImpl.java
+++ b/src/main/java/com/force/i18n/grammar/GrammaticalLabelSetFallbackImpl.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -28,12 +28,9 @@ import com.google.common.collect.Sets;
  * @author stamm
  */
 public final class GrammaticalLabelSetFallbackImpl extends GrammaticalLabelSetImpl implements GrammaticalLabelSetComposite {
-    /**
-	 *
-	 */
-	private static final long serialVersionUID = 1L;  // TODO: Prevent serialization
+    private static final long serialVersionUID = 1L;  // TODO: Prevent serialization
 
-	private static final Logger logger = Logger.getLogger(GrammaticalLabelSetFallbackImpl.class.getName());
+    private static final Logger logger = Logger.getLogger(GrammaticalLabelSetFallbackImpl.class.getName());
 
     private final GrammaticalLabelSet main;
     private final GrammaticalLabelSet fallback;
@@ -194,6 +191,13 @@ public final class GrammaticalLabelSetFallbackImpl extends GrammaticalLabelSetIm
             }
         }
         @Override
+        public Object get(String sectionName, String paramName) {
+            Object overlayValue =  overlay.get(sectionName, paramName);
+            if (overlayValue != null) return overlayValue;
+
+            return fallback.get(sectionName, paramName);
+        }
+        @Override
         public Set<Entry<String, Map<String, Object>>> entrySet() {
             throw new UnsupportedOperationException("You should not iterate through the entry set of a composite property file");
         }
@@ -302,5 +306,4 @@ public final class GrammaticalLabelSetFallbackImpl extends GrammaticalLabelSetIm
             return new GrammaticalLabelSetFallbackImpl(this.main, this.fallback);
         }
     }
-
 }

--- a/src/main/java/com/force/i18n/grammar/GrammaticalTerm.java
+++ b/src/main/java/com/force/i18n/grammar/GrammaticalTerm.java
@@ -10,6 +10,7 @@ package com.force.i18n.grammar;
 import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
 
 import java.io.*;
+import java.util.Objects;
 
 import com.force.i18n.*;
 import com.force.i18n.grammar.impl.LanguageDeclensionFactory;
@@ -24,11 +25,9 @@ import com.force.i18n.grammar.impl.LanguageDeclensionFactory;
  * @author stamm
  */
 public abstract class GrammaticalTerm implements Serializable, Comparable<GrammaticalTerm> {
-    /**
-	 *
-	 */
 	private static final long serialVersionUID = 1L;
-	private final String name;
+
+    private String name; // non-final.  see readObject()
     private transient LanguageDeclension declension;
 
     public enum TermType {
@@ -46,7 +45,6 @@ public abstract class GrammaticalTerm implements Serializable, Comparable<Gramma
         this.name = intern(name);
         this.declension = declension;
     }
-
 
     public String getName() {
         return this.name;
@@ -93,6 +91,20 @@ public abstract class GrammaticalTerm implements Serializable, Comparable<Gramma
     	return typeComp == 0 ? getName().compareTo(o.getName()) : typeComp;
 	}
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        return compareTo((GrammaticalTerm)o) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.declension.getLanguage().ordinal(), getTermType(), this.name);
+    }
 
 	public abstract void toJson(Appendable appendable) throws IOException;
 
@@ -103,6 +115,7 @@ public abstract class GrammaticalTerm implements Serializable, Comparable<Gramma
 
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
+        this.name = intern(name);
         HumanLanguage ul = LanguageProviderFactory.get().getProvider().getLanguage((String)in.readObject());
         this.declension = LanguageDeclensionFactory.get().getDeclension(ul);
     }

--- a/src/main/java/com/force/i18n/grammar/LanguageDictionary.java
+++ b/src/main/java/com/force/i18n/grammar/LanguageDictionary.java
@@ -46,13 +46,13 @@ public final class LanguageDictionary implements Serializable {
 
     // TODO: These could all be made lists when serialized
     // map to Noun
-    private Map<String, Noun> nounMap = new HashMap<String, Noun>();
+    private Map<String, Noun> nounMap = new HashMap<>();
     // map to Noun
-    private Map<String, Noun> nounMapByPluralAlias = new HashMap<String, Noun>();
+    private Map<String, Noun> nounMapByPluralAlias = new HashMap<>();
     // map to Adjective
-    private Map<String, Adjective> adjectiveMap = new HashMap<String, Adjective>();
+    private Map<String, Adjective> adjectiveMap = new HashMap<>();
     // map to Article
-    private Map<String, Article> articleMap = new HashMap<String, Article>();
+    private Map<String, Article> articleMap = new HashMap<>();
     // Override of noun to nounOverrides
     private SortedSetMultimap<Noun, NounVersionOverride> nounVersionOverrides;
     // Whether or not we've been "made skinny".
@@ -733,23 +733,23 @@ public final class LanguageDictionary implements Serializable {
             return atLeast;
         }
 
-		@Override
-		public int hashCode() {
-			return Objects.hash(atLeast, noun);
-		}
+        @Override
+        public int hashCode() {
+            return Objects.hash(atLeast, noun);
+        }
 
-		@Override
-		public boolean equals(Object obj) {
-			if (this == obj)
-				return true;
-			if (obj == null || getClass() != obj.getClass())
-				return false;
-			NounVersionOverride other = (NounVersionOverride) obj;
-			return Double.doubleToLongBits(atLeast) == Double.doubleToLongBits(other.atLeast)
-					&& Objects.equals(noun, other.noun);
-		}
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null || getClass() != obj.getClass())
+                return false;
+            NounVersionOverride other = (NounVersionOverride) obj;
+            return Double.doubleToLongBits(atLeast) == Double.doubleToLongBits(other.atLeast)
+                    && Objects.equals(noun, other.noun);
+        }
 
-		@Override
+        @Override
         public int compareTo(NounVersionOverride o) {
             // comparison is reversed... so you can go in order from newest to oldest and ask atLeast
             return Double.compare(o.getAtLeast(), atLeast);

--- a/src/main/java/com/force/i18n/grammar/LegacyArticledNounForm.java
+++ b/src/main/java/com/force/i18n/grammar/LegacyArticledNounForm.java
@@ -1,30 +1,24 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
 package com.force.i18n.grammar;
 
-import java.io.Serializable;
-
-
-
 /**
  * Implementation of noun form can be supported by a language that can be
  * used support the old incorrect grammar.
- * 
+ *
  * @author stamm
  */
-public final class LegacyArticledNounForm implements NounForm, Serializable {
-    /**
-	 * 
-	 */
-	private static final long serialVersionUID = 1L;
-	private final LanguageArticle article;
+public final class LegacyArticledNounForm implements NounForm {
+    private static final long serialVersionUID = 1L;
+
+    private final LanguageArticle article;
     private final NounForm baseNounForm;
-    
+
     public LegacyArticledNounForm(NounForm baseNounForm, LanguageArticle article) {
         this.baseNounForm = baseNounForm;
         this.article = article;
@@ -58,6 +52,6 @@ public final class LegacyArticledNounForm implements NounForm, Serializable {
     }
 
 
-     
-    
+
+
 }

--- a/src/main/java/com/force/i18n/grammar/Noun.java
+++ b/src/main/java/com/force/i18n/grammar/Noun.java
@@ -31,11 +31,11 @@ public abstract class Noun extends GrammaticalTerm implements Cloneable {
     private static final long serialVersionUID = 1L;
 
     private final NounType nounType;
-    private final String entityName;
-    private final String pluralAlias;
+    private String entityName;              // not final for readResolve()
+    private String pluralAlias;             // not final for readResolve()
     private LanguageGender gender;          // TODO: make final
     private LanguageStartsWith startsWith;  // TODO: make final
-    private final String access;
+    private String access;                  // not final for readResolve()
     private final boolean isStandardField; // specifies whether this label is a standard field or not. For the Rename
     private final boolean isCopied;        // specifies whether this noun was copied from english (or another fallback language)
 
@@ -175,7 +175,7 @@ public abstract class Noun extends GrammaticalTerm implements Cloneable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getName(), getAllDefinedValues(), gender, startsWith);
+        return Objects.hash(super.hashCode(), getAllDefinedValues(), gender, startsWith);
     }
 
     /**
@@ -397,6 +397,13 @@ public abstract class Noun extends GrammaticalTerm implements Cloneable {
                 return n1.getKey().compareTo(n2.getKey());
             }
         });
+    }
+
+    protected Object readResolve() {
+        this.entityName = intern(entityName);
+        this.pluralAlias = intern(pluralAlias);
+        this.access = intern(access);
+        return this;
     }
 
     /**

--- a/src/main/java/com/force/i18n/grammar/NounModifier.java
+++ b/src/main/java/com/force/i18n/grammar/NounModifier.java
@@ -9,6 +9,7 @@ package com.force.i18n.grammar;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
@@ -23,12 +24,9 @@ import com.force.i18n.commons.text.TextUtil;
  * @author stamm
  */
 public abstract class NounModifier extends GrammaticalTerm {
-    /**
-	 *
-	 */
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-	public NounModifier(LanguageDeclension declension, String name) {
+    protected NounModifier(LanguageDeclension declension, String name) {
         super(declension, name);
     }
 
@@ -70,7 +68,12 @@ public abstract class NounModifier extends GrammaticalTerm {
     public abstract String getDefaultValue();
 
     @Override
-    public final boolean equals(Object obj) {
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), getStartsWith(), getPosition(), getAllValues());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
         if (this == obj) return true;
         if (obj instanceof NounModifier) {
             NounModifier nm = (NounModifier)obj;
@@ -84,14 +87,14 @@ public abstract class NounModifier extends GrammaticalTerm {
 
     @Override
 	public void toJson(Appendable appendable) throws IOException {
-    	appendable.append("{\"t\":\""+getTermType().getCharId()+"\",\"l\":\"");
-    	appendable.append(getName());
-    	appendable.append("\",");
-    	if (getDeclension().hasStartsWith() && getStartsWith() != null) {
-    		appendable.append("\"s\":\"").append(getStartsWith().getDbValue()).append("\",");
-    	}
-    	appendable.append("\"v\":{");
-    	appendable.append(new TreeMap<>(getAllValues()).entrySet().stream().map(e->"\""+e.getKey().getKey()+"\":\""+TextUtil.escapeForJsonString(e.getValue())+"\"").collect(Collectors.joining(",")));
-    	appendable.append("}}");
-	}
+        appendable.append("{\"t\":\"" + getTermType().getCharId() + "\",\"l\":\"");
+        appendable.append(getName());
+        appendable.append("\",");
+        if (getDeclension().hasStartsWith() && getStartsWith() != null) {
+            appendable.append("\"s\":\"").append(getStartsWith().getDbValue()).append("\",");
+        }
+        appendable.append("\"v\":{");
+        appendable.append(new TreeMap<>(getAllValues()).entrySet().stream().map(e->"\""+e.getKey().getKey()+"\":\""+TextUtil.escapeForJsonString(e.getValue())+"\"").collect(Collectors.joining(",")));
+        appendable.append("}}");
+    }
 }

--- a/src/main/java/com/force/i18n/grammar/impl/AmharicDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/AmharicDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -23,12 +23,12 @@ import com.google.common.collect.ImmutableSet;
  * The declension of nouns for Amharic.  Not fully supported.
  *
  * Amharic has 3 cases (Nom, Acc, &amp; Gen), M/F Gender, plural, and definitiveness.
- * It has bound possessive forms differening based on case, gender, politeness, etc.  
+ * It has bound possessive forms differening based on case, gender, politeness, etc.
  * So we're not going to support it directly.  Definitiveness moves to prepositional
  * adjectives depending.
  *
  * Case endings could be derived, but it would be a fair amount of work to automatically
- * derive the vowel changing endings from the Ethiopic bloc.  
+ * derive the vowel changing endings from the Ethiopic bloc.
  *
  * @author stamm
  * @since 1.2
@@ -82,38 +82,50 @@ class AmharicDeclension extends SemiticDeclension {
      * Amharic nouns are inflected for case, number, possessive, and article.  Everything that is
      */
     static class AmharicNounForm extends ComplexNounForm {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private final LanguageCase caseType;
+        private static final long serialVersionUID = 1L;
+
+        private final LanguageCase caseType;
         private final LanguageNumber number;
-        private final LanguagePossessive possesive;
+        private final LanguagePossessive possessive;
         private final LanguageArticle article;
 
-        public AmharicNounForm(LanguageDeclension declension, LanguageNumber number, LanguageCase caseType, LanguagePossessive possesive, LanguageArticle article, int ordinal) {
+        public AmharicNounForm(LanguageDeclension declension, LanguageNumber number, LanguageCase caseType, LanguagePossessive possessive, LanguageArticle article, int ordinal) {
             super(declension, ordinal);
             this.number = number;
             this.caseType = caseType;
-            this.possesive = possesive;
+            this.possessive = possessive;
             this.article = article;
         }
 
         @Override public LanguageArticle getArticle() { return this.article; }
         @Override public LanguageCase getCase() {  return this.caseType; }
         @Override public LanguageNumber getNumber() {  return this.number; }
-        @Override public LanguagePossessive getPossessive() { return possesive;}
+        @Override public LanguagePossessive getPossessive() { return possessive;}
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), this.caseType, this.number, this.possessive, this.article);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (other instanceof AmharicNounForm) {
+                AmharicNounForm o = this.getClass().cast(other);
+                return super.equals(other) && this.caseType == o.caseType && this.number == o.number
+                        && this.possessive == o.possessive && this.article == o.article;
+            }
+            return false;
+        }
     }
 
     /**
      * Amharic nouns are inflected for case, number, gender, and article.  Oh my.
      */
     static class AmharicAdjectiveForm extends ComplexAdjectiveForm {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private final LanguageGender gender;
+        private static final long serialVersionUID = 1L;
+
+        private final LanguageGender gender;
         private final LanguageCase caseType;
         private final LanguageNumber number;
         private final LanguageArticle article;
@@ -134,33 +146,47 @@ class AmharicDeclension extends SemiticDeclension {
         @Override public LanguageStartsWith getStartsWith() {  return LanguageStartsWith.CONSONANT; }
         @Override public LanguageGender getGender() {  return this.gender; }
         @Override public LanguagePossessive getPossessive() { return possessive; }
-		@Override
-		public String getKey() {
-			return getGender().getDbValue() + "-" + getNumber().getDbValue() + "-" + getCase().getDbValue() + "-" + getArticle().getDbValue() + "-" + getPossessive().getDbValue();
-		}
+
+        @Override
+        public String getKey() {
+            return getGender().getDbValue() + "-" + getNumber().getDbValue() + "-" + getCase().getDbValue() + "-" + getArticle().getDbValue() + "-" + getPossessive().getDbValue();
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), this.gender, this.caseType, this.number, this.article,
+                    this.possessive);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (other instanceof AmharicAdjectiveForm) {
+                AmharicAdjectiveForm o = this.getClass().cast(other);
+                return super.equals(other) && this.gender == o.gender && this.caseType == o.caseType
+                        && this.number == o.number && this.article == o.article && this.possessive == o.possessive;
+            }
+            return false;
+        }
     }
 
     public static final class AmharicNoun extends ComplexArticledNoun<AmharicNounForm> {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private static final Logger logger = Logger.getLogger(AmharicNoun.class.getName());
+        private static final long serialVersionUID = 1L;
+
+        private static final Logger logger = Logger.getLogger(AmharicNoun.class.getName());
         AmharicNoun(AmharicDeclension declension, String name, String pluralAlias, NounType type, String entityName, LanguageGender gender,  String access, boolean isStandardField, boolean isCopied) {
             super(declension, name, pluralAlias, type, entityName, LanguageStartsWith.CONSONANT, gender, access, isStandardField, isCopied);
         }
 
         @Override
-		protected final Class<AmharicNounForm> getFormClass() {
-        	return AmharicNounForm.class;
-		}
+        protected final Class<AmharicNounForm> getFormClass() {
+            return AmharicNounForm.class;
+        }
 
-
-		@Override
+        @Override
         public String getExactString(NounForm form) {
             return super.getExactString(form);
         }
-
 
         @Override
         protected boolean validateValues(String name, LanguageCase _case) {
@@ -178,7 +204,7 @@ class AmharicDeclension extends SemiticDeclension {
                     		logger.info("###\tError: The noun " + name + " has no " + form
                     					+ " form and no default could be found");
                     		return false;
-                        }	
+                        }
                     } else if (requiredForms.contains(form)) {
                         // TODO SLT: This logic seems faulty.  Why'd we bother
                         logger.finest("###\tError: The noun " + name + " has no " + form + " form");
@@ -193,24 +219,22 @@ class AmharicDeclension extends SemiticDeclension {
 
 
     protected static class AmharicAdjective extends ComplexAdjective<AmharicAdjectiveForm> {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		// The "keys" here are StartsWith, Gender, and Plurality
+        private static final long serialVersionUID = 1L;
+
+        // The "keys" here are StartsWith, Gender, and Plurality
         AmharicAdjective(LanguageDeclension declension, String name, LanguagePosition position) {
             super(declension, name, position);
         }
 
         @Override
-		protected final Class<AmharicAdjectiveForm> getFormClass() {
-        	return AmharicAdjectiveForm.class;
-		}
+        protected final Class<AmharicAdjectiveForm> getFormClass() {
+            return AmharicAdjectiveForm.class;
+        }
 
-		@Override
+        @Override
         protected String deriveDefaultString(AdjectiveForm form, String value, AdjectiveForm baseForm) {
-			// TODO SLT: Derive adjectives where we can
-			return super.deriveDefaultString(form, value, baseForm);
+            // TODO SLT: Derive adjectives where we can
+            return super.deriveDefaultString(form, value, baseForm);
         }
 
         @Override
@@ -232,7 +256,7 @@ class AmharicDeclension extends SemiticDeclension {
     }
 
     static final EnumSet<LanguagePossessive> REQUIRED_POSESSIVES = EnumSet.of(LanguagePossessive.NONE, LanguagePossessive.FIRST, LanguagePossessive.SECOND);
-    static final EnumSet<LanguageCase> ALLOWED_CASES = EnumSet.of(NOMINATIVE, ACCUSATIVE, GENITIVE); 
+    static final EnumSet<LanguageCase> ALLOWED_CASES = EnumSet.of(NOMINATIVE, ACCUSATIVE, GENITIVE);
     static final EnumSet<LanguageCase> REQUIRED_CASES = EnumSet.of(NOMINATIVE);  // Only do nomitive.
 
     @Override
@@ -283,12 +307,12 @@ class AmharicDeclension extends SemiticDeclension {
 	@Override
 	protected String getDefiniteArticlePrefix(LanguageStartsWith startsWith) {
 		// Amharic, unlike the related Tigrinya (እታ), doesn't have a definite article prefix,
-		// but it has a suffix which changes the last character of the word or adds one depending on 
-		// gender and case.  
-		// A boy (ልጅ).  The boy (ልጁ).  
+		// but it has a suffix which changes the last character of the word or adds one depending on
+		// gender and case.
+		// A boy (ልጅ).  The boy (ልጁ).
 		// A dog (ውሻ).  The dog (ውሻው).
 		// When full support is required
 		return "";
 	}
-    
+
 }

--- a/src/main/java/com/force/i18n/grammar/impl/ArabicDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/ArabicDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -89,38 +89,50 @@ class ArabicDeclension extends SemiticDeclension {
      * Arabic nouns are inflected for case, number, possessive, and article.  Everything that is
      */
     static class ArabicNounForm extends ComplexNounForm {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private final LanguageCase caseType;
+        private static final long serialVersionUID = 1L;
+
+        private final LanguageCase caseType;
         private final LanguageNumber number;
-        private final LanguagePossessive possesive;
+        private final LanguagePossessive possessive;
         private final LanguageArticle article;
 
-        public ArabicNounForm(LanguageDeclension declension, LanguageNumber number, LanguageCase caseType, LanguagePossessive possesive, LanguageArticle article, int ordinal) {
+        public ArabicNounForm(LanguageDeclension declension, LanguageNumber number, LanguageCase caseType, LanguagePossessive possessive, LanguageArticle article, int ordinal) {
             super(declension, ordinal);
             this.number = number;
             this.caseType = caseType;
-            this.possesive = possesive;
+            this.possessive = possessive;
             this.article = article;
         }
 
         @Override public LanguageArticle getArticle() { return this.article; }
         @Override public LanguageCase getCase() {  return this.caseType; }
         @Override public LanguageNumber getNumber() {  return this.number; }
-        @Override public LanguagePossessive getPossessive() { return possesive;}
+        @Override public LanguagePossessive getPossessive() { return possessive;}
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), this.caseType, this.number, this.possessive, this.article);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (other instanceof ArabicNounForm) {
+                ArabicNounForm o = this.getClass().cast(other);
+                return super.equals(other) && this.caseType == o.caseType && this.number == o.number
+                        && this.possessive == o.possessive && this.article == o.article;
+            }
+            return false;
+        }
     }
 
     /**
      * Arabic nouns are inflected for case, number, gender, and article.  Oh my.
      */
     static class ArabicAdjectiveForm extends ComplexAdjectiveForm {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private final LanguageGender gender;
+        private static final long serialVersionUID = 1L;
+
+        private final LanguageGender gender;
         private final LanguageCase caseType;
         private final LanguageNumber number;
         private final LanguageArticle article;
@@ -141,10 +153,29 @@ class ArabicDeclension extends SemiticDeclension {
         @Override public LanguageStartsWith getStartsWith() {  return LanguageStartsWith.CONSONANT; }
         @Override public LanguageGender getGender() {  return this.gender; }
         @Override public LanguagePossessive getPossessive() { return possessive; }
-		@Override
-		public String getKey() {
-			return getGender().getDbValue() + "-" + getNumber().getDbValue() + "-" + getCase().getDbValue() + "-" + getArticle().getDbValue() + "-" + getPossessive().getDbValue();
-		}
+
+        @Override
+        public String getKey() {
+            return getGender().getDbValue() + "-" + getNumber().getDbValue() + "-" + getCase().getDbValue() + "-" + getArticle().getDbValue() + "-" + getPossessive().getDbValue();
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), this.gender, this.caseType, this.number, this.article,
+                    this.possessive);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (other instanceof ArabicAdjectiveForm) {
+                ArabicAdjectiveForm o = this.getClass().cast(other);
+                return super.equals(other) && this.gender == o.gender && this.caseType == o.caseType
+                        && this.number == o.number && this.article == o.article && this.possessive == o.possessive;
+            }
+            return false;
+        }
+
     }
 
     /**
@@ -170,22 +201,19 @@ class ArabicDeclension extends SemiticDeclension {
     }
 
     public static final class ArabicNoun extends ComplexArticledNoun<ArabicNounForm> {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private static final Logger logger = Logger.getLogger(ArabicNoun.class.getName());
+        private static final long serialVersionUID = 1L;
+        private static final Logger logger = Logger.getLogger(ArabicNoun.class.getName());
+
         ArabicNoun(ArabicDeclension declension, String name, String pluralAlias, NounType type, String entityName, LanguageGender gender,  String access, boolean isStandardField, boolean isCopied) {
             super(declension, name, pluralAlias, type, entityName, LanguageStartsWith.CONSONANT, gender, access, isStandardField, isCopied);
         }
 
         @Override
-		protected final Class<ArabicNounForm> getFormClass() {
-        	return ArabicNounForm.class;
-		}
+        protected final Class<ArabicNounForm> getFormClass() {
+            return ArabicNounForm.class;
+        }
 
-
-		@Override
+        @Override
         public String getExactString(NounForm form) {
             // Autoderive the accusative.
             if (form.getCase() == LanguageCase.ACCUSATIVE) {
@@ -198,7 +226,6 @@ class ArabicDeclension extends SemiticDeclension {
             }
             return super.getExactString(form);
         }
-
 
         @Override
         protected boolean validateValues(String name, LanguageCase _case) {
@@ -231,7 +258,7 @@ class ArabicDeclension extends SemiticDeclension {
                             setString(val, form);
                         }
                     } else if (form.getNumber() == LanguageNumber.DUAL) {
-                    	// Default dual to plural 
+                    	// Default dual to plural
                         String val = getCloseButNoCigarString(form);
                         if (val != null) {
                             setString(val, form);
@@ -251,21 +278,19 @@ class ArabicDeclension extends SemiticDeclension {
 
 
     protected static class ArabicAdjective extends ComplexAdjective<ArabicAdjectiveForm> {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
+
 		// The "keys" here are StartsWith, Gender, and Plurality
         ArabicAdjective(LanguageDeclension declension, String name, LanguagePosition position) {
             super(declension, name, position);
         }
 
         @Override
-		protected final Class<ArabicAdjectiveForm> getFormClass() {
-        	return ArabicAdjectiveForm.class;
-		}
+        protected final Class<ArabicAdjectiveForm> getFormClass() {
+            return ArabicAdjectiveForm.class;
+        }
 
-		@Override
+        @Override
         protected String deriveDefaultString(AdjectiveForm form, String value, AdjectiveForm baseFormed) {
             if (form.getPossessive() != LanguagePossessive.NONE) {
                 return value; // Already has the right prefix
@@ -311,17 +336,14 @@ class ArabicDeclension extends SemiticDeclension {
         return DEFAULT_DEFINITE_PREFIX;
     }
 
-
     static final EnumSet<LanguagePossessive> REQUIRED_POSESSIVES = EnumSet.of(LanguagePossessive.NONE, LanguagePossessive.FIRST, LanguagePossessive.SECOND);
     static final EnumSet<LanguageCase> ALLOWED_CASES = EnumSet.of(NOMINATIVE, ACCUSATIVE);  // Arabic has genitive, but it's the same as the nominative in nearly all cases
     static final EnumSet<LanguageCase> REQUIRED_CASES = EnumSet.of(NOMINATIVE);  // Arabic has genitive, but it's the same as the nominative in nearly all cases
-
 
     @Override
     public EnumSet<LanguagePossessive> getRequiredPossessive() {
         return REQUIRED_POSESSIVES;
     }
-
 
     @Override
     public EnumSet<LanguageCase> getRequiredCases() {
@@ -367,5 +389,4 @@ class ArabicDeclension extends SemiticDeclension {
     public Collection< ? extends NounForm> getOtherForms() {
         return nounForms;
     }
-    
 }

--- a/src/main/java/com/force/i18n/grammar/impl/ArmenianDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/ArmenianDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -24,9 +24,9 @@ import com.google.common.collect.ImmutableList;
  * its own class.  It has 7 cases and no gender.
  *
  * TODO: It has definite article, but the definitiveness is dependent on the endsWith of the current
- * word, along with the startsWith of the next word, and some special rules depending on dialect.  
+ * word, along with the startsWith of the next word, and some special rules depending on dialect.
  * File an issue if you need better Armenian support, and we can look into supporting all of this.
- * 
+ *
  * There is an unchanging indefinite article, մի, so it isn't included in the grammar yet
  *
  * @author stamm
@@ -86,11 +86,9 @@ class ArmenianDeclension extends AbstractLanguageDeclension {
      * Armenian nouns are inflected for case, and number
      */
     static class ArmenianNounForm extends ComplexNounForm {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private final LanguageCase caseType;
+        private static final long serialVersionUID = 1L;
+
+        private final LanguageCase caseType;
         private final LanguageNumber number;
         private final LanguageArticle article;
 
@@ -105,38 +103,55 @@ class ArmenianDeclension extends AbstractLanguageDeclension {
         @Override public LanguageCase getCase() {  return this.caseType; }
         @Override public LanguageNumber getNumber() {  return this.number; }
         @Override public LanguagePossessive getPossessive() { return LanguagePossessive.NONE;}
+
         @Override
         public String getKey() {
             return getNumber().getDbValue() + "-" + getCase().getDbValue() + "-" + getArticle().getDbValue();
         }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), this.caseType, this.number, this.article);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (other instanceof ArmenianNounForm) {
+                ArmenianNounForm o = this.getClass().cast(other);
+                return super.equals(other) && this.caseType == o.caseType && this.number == o.number
+                        && this.article == o.article;
+            }
+            return false;
+        }
+
         @Override
         public String toString() {
             return "ArmenianNF:" + getKey();
         }
     }
 
-
     /**
      * Represents an Armenian noun.
      * See ArmenianNounForm for more info
      */
     public static class ArmenianNoun extends ComplexNoun<ArmenianNounForm> {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		// Store everything for now.
+        private static final long serialVersionUID = 1L;
+
         ArmenianNoun(ArmenianDeclension declension, String name, String pluralAlias, NounType type, String entityName, LanguageStartsWith startsWith, String access, boolean isStandardField, boolean isCopiedFromDefault) {
             super(declension, name, pluralAlias, type, entityName, startsWith, LanguageGender.NEUTER, access, isStandardField, isCopiedFromDefault);
         }
+
         @Override
-		protected final Class<ArmenianNounForm> getFormClass() {
+        protected final Class<ArmenianNounForm> getFormClass() {
         	return ArmenianNounForm.class;
-		}
-		@Override
+        }
+
+        @Override
         protected boolean validateValues(String name, LanguageCase _case) {
             return defaultValidate(name, getDeclension().getFieldForms());
         }
+
         @Override
         protected boolean validateGender(String name) {
             if (getGender() != LanguageGender.NEUTER)

--- a/src/main/java/com/force/i18n/grammar/impl/BalticDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/BalticDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -67,11 +67,9 @@ class BalticDeclension extends AbstractLanguageDeclension {
 
 
     static class BalticAdjectiveForm extends ComplexAdjectiveForm {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private final LanguageNumber number;
+        private static final long serialVersionUID = 1L;
+
+        private final LanguageNumber number;
         private final LanguageCase caseType;
         private final LanguageGender gender;
 
@@ -88,35 +86,48 @@ class BalticDeclension extends AbstractLanguageDeclension {
         @Override public LanguageStartsWith getStartsWith() {  return LanguageStartsWith.CONSONANT; }
         @Override public LanguageGender getGender() {  return this.gender; }
         @Override public LanguagePossessive getPossessive() { return LanguagePossessive.NONE; }
-		@Override
-		public String getKey() {
-			return getGender().getDbValue() + "-" + getNumber().getDbValue() + "-" + getCase().getDbValue();
-		}
+
+        @Override
+        public String getKey() {
+            return getGender().getDbValue() + "-" + getNumber().getDbValue() + "-" + getCase().getDbValue();
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), this.caseType, this.number, this.gender);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (other instanceof BalticAdjectiveForm) {
+                BalticAdjectiveForm o = this.getClass().cast(other);
+                return super.equals(other) && this.caseType == o.caseType && this.number == o.number
+                        && this.gender == o.gender;
+            }
+            return false;
+        }
     }
 
     /**
      * Represents a baltic adjective
      */
     public static class BalticAdjective extends ComplexAdjective<BalticAdjectiveForm> {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
 
         BalticAdjective(LanguageDeclension declension, String name, LanguagePosition position) {
             super(declension, name, position);
         }
 
         @Override
-		protected final Class<BalticAdjectiveForm> getFormClass() {
-        	return BalticAdjectiveForm.class;
-		}
+        protected final Class<BalticAdjectiveForm> getFormClass() {
+            return BalticAdjectiveForm.class;
+        }
 
-		@Override
+        @Override
         public boolean validate(String name) {
             return defaultValidate(name, ImmutableSet.of(getDeclension().getAdjectiveForm(LanguageStartsWith.CONSONANT, LanguageGender.FEMININE, LanguageNumber.SINGULAR, LanguageCase.NOMINATIVE, LanguageArticle.ZERO, LanguagePossessive.NONE)));
         }
-
    }
 
 

--- a/src/main/java/com/force/i18n/grammar/impl/BantuDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/BantuDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2019, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 package com.force.i18n.grammar.impl;
@@ -19,11 +19,11 @@ import com.google.common.collect.ImmutableSet;
 
 /**
  * Declension for Bantu languages, with noun classes.
- * 
+ *
  * For simplicity, we ask for nouns with singular and plural, and then ask for the noun class.
  * So when expressing a translation for "Account", we'll ask for
  * "Akaunti", "Akaunti", N Class (IX/X)
- * 
+ *
 
  *
  * @author stamm
@@ -49,10 +49,8 @@ abstract class BantuDeclension extends AbstractLanguageDeclension {
 
 
     static class BantuAdjectiveForm extends ComplexAdjectiveForm {
-        /**
-         *
-         */
         private static final long serialVersionUID = 1L;
+
         private final LanguageNumber number;
         private final LanguageGender gender;
 
@@ -68,9 +66,25 @@ abstract class BantuDeclension extends AbstractLanguageDeclension {
         @Override public LanguageStartsWith getStartsWith() {  return LanguageStartsWith.CONSONANT; }
         @Override public LanguageGender getGender() {  return this.gender; }
         @Override public LanguagePossessive getPossessive() { return LanguagePossessive.NONE; }
+
         @Override
         public String getKey() {
             return getGender().getDbValue() + "-" + getNumber().getDbValue();
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), this.number, this.gender);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (other instanceof BantuAdjectiveForm) {
+                BantuAdjectiveForm o = this.getClass().cast(other);
+                return super.equals(other) && this.number == o.number && this.gender == o.gender;
+            }
+            return false;
         }
     }
 
@@ -78,9 +92,6 @@ abstract class BantuDeclension extends AbstractLanguageDeclension {
      * Represents a bantu adjective
      */
     public static class BantuAdjective extends ComplexAdjective<BantuAdjectiveForm> {
-        /**
-         *
-         */
         private static final long serialVersionUID = 1L;
 
         BantuAdjective(LanguageDeclension declension, String name, LanguagePosition position) {
@@ -96,23 +107,18 @@ abstract class BantuDeclension extends AbstractLanguageDeclension {
         public boolean validate(String name) {
             return defaultValidate(name, ImmutableSet.of(getDeclension().getAdjectiveForm(LanguageStartsWith.CONSONANT, LanguageGender.CLASS_I, LanguageNumber.SINGULAR, LanguageCase.NOMINATIVE, LanguageArticle.ZERO, LanguagePossessive.NONE)));
         }
-
    }
 
+   @Override
+   public Adjective createAdjective(String name, LanguageStartsWith startsWith, LanguagePosition position) {
+       return new BantuAdjective(this, name, position);
+   }
 
-    @Override
-    public Adjective createAdjective(String name, LanguageStartsWith startsWith, LanguagePosition position) {
-        return new BantuAdjective(this, name, position);
-    }
-
-
-    
     @Override
     public Noun createNoun(String name, String pluralAlias, NounType type, String entityName, LanguageStartsWith startsWith,
             LanguageGender gender, String access, boolean isStandardField, boolean isCopied) {
         return new SimplePluralNounWithGender(this, name, pluralAlias, type, entityName, gender, access, isStandardField, isCopied);
     }
-
 
     @Override
     public List< ? extends AdjectiveForm> getAdjectiveForms() {
@@ -157,13 +163,13 @@ abstract class BantuDeclension extends AbstractLanguageDeclension {
     public boolean hasStartsWith() {
         return false;
     }
-    
+
     /**
      * Declension for the Kiswahili language
      * */
     /*
      * An example of specifying adjectives would be
- 
+
  <adjective name="New">
     <value gender="M-wa" plural="n">Mpya</value>
     <value gender="M-wa" plural="y">Wapya</value>
@@ -200,7 +206,7 @@ abstract class BantuDeclension extends AbstractLanguageDeclension {
     <value gender="Mu" plural="y">Mwangu</value>
  </adjective>
 
-     * 
+     *
      *
      * @author stamm
      * @since 220
@@ -218,7 +224,7 @@ abstract class BantuDeclension extends AbstractLanguageDeclension {
 
     /**
      * Declension for the isiZulu language
-     * 
+     *
      */
  /*
      * An example of specifying adjectives would be

--- a/src/main/java/com/force/i18n/grammar/impl/BengaliDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/BengaliDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -20,8 +20,8 @@ import com.google.common.collect.ImmutableList;
 
 
 /**
- * Bengali is our first Indic language. Spec from Localization: 
- * 
+ * Bengali is our first Indic language. Spec from Localization:
+ *
  * Although this is Indo-Aryan, because of it's use of definite articles, we keep it separate.
  *
  * @author cgrabill
@@ -30,7 +30,7 @@ class BengaliDeclension extends ArticledDeclension {
 
     private final List<BengaliNounForm> entityForms;
     private final List<BengaliNounForm> fieldForms;
-    
+
     public BengaliDeclension(HumanLanguage language) {
     	super(language);
         // Generate the different forms from subclass methods
@@ -51,14 +51,15 @@ class BengaliDeclension extends ArticledDeclension {
         this.entityForms = entityBuilder.build();
         this.fieldForms = fieldBuilder.build();
     }
-        
+
     static class BengaliNounForm extends ComplexNounForm {
-		private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
+
         private final LanguageCase caseType;
         private final LanguageNumber number;
         private final LanguageArticle article;
-        
-        BengaliNounForm(LanguageDeclension declension, LanguageNumber number, LanguageCase caseType, 
+
+        BengaliNounForm(LanguageDeclension declension, LanguageNumber number, LanguageCase caseType,
                 LanguageArticle article, int ordinal) {
             super(declension, ordinal);
             this.number = number;
@@ -70,26 +71,46 @@ class BengaliDeclension extends ArticledDeclension {
         @Override public LanguageCase getCase() { return caseType; }
         @Override public LanguageArticle getArticle() { return article; }
         @Override public LanguagePossessive getPossessive() { return LanguagePossessive.NONE; }
+
         @Override
         public String getKey() {
             return getNumber().getDbValue() + "-" + getCase().getDbValue() + "-" + getArticle().getDbValue();
         }
+
         @Override
         public String toString() {
             return "BengaliNF:" + getKey();
         }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), this.caseType, this.number, this.article);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+
+            if (other instanceof BengaliNounForm) {
+                BengaliNounForm otherNf = BengaliNounForm.class.cast(other);
+                return super.equals(other) && this.caseType == otherNf.caseType && this.number == otherNf.number
+                        && this.article == otherNf.article;
+            }
+            return false;
+        }
     }
-    
+
     /**
      * Represents a Bengali noun. See BengaliNounForm for more info.
      */
     public static class BengaliNoun extends LegacyArticledNoun {
-		private static final long serialVersionUID = 1L;
-        //store everything
-        private transient Map<BengaliNounForm, String> values = new HashMap<BengaliNounForm, String>();
+        private static final long serialVersionUID = 1L;
 
-        BengaliNoun(BengaliDeclension declension, String name, String pluralAlias, NounType type, 
-                String entityName, String access, LanguageGender gender, 
+        //store everything
+        private transient Map<BengaliNounForm, String> values = new HashMap<>();
+
+        BengaliNoun(BengaliDeclension declension, String name, String pluralAlias, NounType type,
+                String entityName, String access, LanguageGender gender,
                 boolean isStandardField, boolean isCopiedFromDefault ) {
             super(declension, name, pluralAlias, type, entityName, LanguageStartsWith.CONSONANT,
                     gender, access, isStandardField, isCopiedFromDefault);
@@ -120,7 +141,7 @@ class BengaliDeclension extends ArticledDeclension {
         public void makeSkinny() {
             values = makeSkinny(values);
         }
-        
+
         /**
          * Need to override so that a cloned BengaliNoun's values map is a HashMap.
          * Else, if you clone() after makeSkinny() has been called, you won't
@@ -129,21 +150,22 @@ class BengaliDeclension extends ArticledDeclension {
         @Override
         public Noun clone() {
             BengaliNoun noun = (BengaliNoun) super.clone();
-            noun.values = new HashMap<BengaliNounForm,String>(noun.values);
+            noun.values = new HashMap<>(noun.values);
             return noun;
         }
-        
+
         // Override read and write, or else you'll get mysterious exception
         private void writeObject(ObjectOutputStream out) throws IOException {
             out.defaultWriteObject();
             ComplexGrammaticalForm.serializeFormMap(out, values);
         }
+
         private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
             in.defaultReadObject();
             this.values = ComplexGrammaticalForm.deserializeFormMap(in, getDeclension(), TermType.Noun);
         }
     }
-    
+
     @Override
     public List<? extends NounForm> getAllNounForms() {
         return entityForms;
@@ -161,7 +183,7 @@ class BengaliDeclension extends ArticledDeclension {
 
     @Override
     public Collection<? extends NounForm> getOtherForms() {
-        return getAllNounForms(); //TODO is this close? 
+        return getAllNounForms(); //TODO is this close?
     }
 
     @Override
@@ -174,7 +196,7 @@ class BengaliDeclension extends ArticledDeclension {
     public Noun createNoun(String name, String pluralAlias, NounType type, String entityName,
             LanguageStartsWith startsWith, LanguageGender gender, String access, boolean isStandardField,
             boolean isCopied) {
-        return new BengaliNoun(this, name, pluralAlias, type, entityName, access, gender, 
+        return new BengaliNoun(this, name, pluralAlias, type, entityName, access, gender,
                 isStandardField, isCopied);
     }
 
@@ -192,20 +214,20 @@ class BengaliDeclension extends ArticledDeclension {
     public boolean hasStartsWith() {
         return false;
     }
-    
+
     @Override
     public EnumSet<LanguageCase> getRequiredCases() {
-        return EnumSet.of(LanguageCase.NOMINATIVE, 
-                          LanguageCase.OBJECTIVE, 
-                          LanguageCase.GENITIVE, 
+        return EnumSet.of(LanguageCase.NOMINATIVE,
+                          LanguageCase.OBJECTIVE,
+                          LanguageCase.GENITIVE,
                           LanguageCase.LOCATIVE);
     }
-    
+
     @Override
     public boolean hasArticleInNounForm() {
         return true;
     }
-    
+
     @Override
     public Set<LanguageArticle> getAllowedArticleTypes() {
         return EnumSet.of(LanguageArticle.ZERO, LanguageArticle.DEFINITE);

--- a/src/main/java/com/force/i18n/grammar/impl/BulgarianDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/BulgarianDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -68,11 +68,12 @@ class BulgarianDeclension extends AbstractLanguageDeclension {
 		super(language);
 	}
 
-	private static final Logger logger = Logger.getLogger(BulgarianDeclension.class.getName());
+    private static final Logger logger = Logger.getLogger(BulgarianDeclension.class.getName());
+
     /**
      * Adjective form for languages that don't care about "starts with"
      */
-    public static enum BulgarianModifierForm implements AdjectiveForm {
+    public enum BulgarianModifierForm implements AdjectiveForm {
         // TODO: We're not going to have to ask the translator for all of these forms.
         SINGULAR_MASCULINE(LanguageNumber.SINGULAR, LanguageGender.MASCULINE),
         SINGULAR_FEMININE(LanguageNumber.SINGULAR, LanguageGender.FEMININE),
@@ -108,16 +109,19 @@ class BulgarianDeclension extends AbstractLanguageDeclension {
         @Override public LanguageGender getGender() {return this.gender;}
         @Override public LanguageStartsWith getStartsWith() { return LanguageStartsWith.CONSONANT; }
         @Override public LanguagePossessive getPossessive() { return LanguagePossessive.NONE; }
-		@Override
-		public String getKey() {
-			return getGender().getDbValue() + "-" + getNumber().getDbValue() + "-" + getCase().getDbValue() + "-" + getArticle().getDbValue();
-		}
-		@Override
-		public void appendJsFormReplacement(Appendable a, String termFormVar, String genderVar, String startsWithVar)
-				throws IOException {
-			a.append(genderVar+"+"+termFormVar+".substr(1)");
-		}
-	}
+
+        @Override
+        public String getKey() {
+            return getGender().getDbValue() + "-" + getNumber().getDbValue() + "-" + getCase().getDbValue() + "-"
+                    + getArticle().getDbValue();
+        }
+
+        @Override
+        public void appendJsFormReplacement(Appendable a, String termFormVar, String genderVar, String startsWithVar)
+                throws IOException {
+            a.append(genderVar + "+" + termFormVar + ".substr(1)");
+        }
+    }
 
     public static enum BulgarianNounForm implements NounForm {
         SINGULAR(LanguageNumber.SINGULAR, LanguageCase.NOMINATIVE),
@@ -155,12 +159,11 @@ class BulgarianDeclension extends AbstractLanguageDeclension {
      * @author stamm
      */
     protected static class BulgarianNoun extends Noun {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		String singular;
+        private static final long serialVersionUID = 1L;
+
+        String singular;
         String plural;
+
         protected BulgarianNoun(BulgarianDeclension declension, String name, String pluralAlias, NounType type, String entityName, LanguageStartsWith startsWith, LanguageGender gender, String access, boolean isStandardField, boolean isCopiedFromDefault) {
             super(declension, name, pluralAlias, type, entityName, startsWith, gender, access, isStandardField, isCopiedFromDefault);
         }
@@ -258,16 +261,22 @@ class BulgarianDeclension extends AbstractLanguageDeclension {
         @Override
         public void makeSkinny() {
         }
+
+        @Override
+        protected Object readResolve() {
+            super.readResolve();
+            this.singular = intern(this.singular);
+            this.plural = intern(this.plural);
+            return this;
+        }
     }
 
-
     protected static class BulgarianAdjective extends Adjective {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		// The "keys" here are StartsWith, Gender, and Plurality
-        EnumMap<BulgarianModifierForm,String> values = new EnumMap<BulgarianModifierForm,String>(BulgarianModifierForm.class);
+        private static final long serialVersionUID = 1L;
+
+        // The "keys" here are StartsWith, Gender, and Plurality
+        EnumMap<BulgarianModifierForm, String> values = new EnumMap<>(BulgarianModifierForm.class);
+
         BulgarianAdjective(LanguageDeclension declension, String name, LanguagePosition position) {
             super(declension, name, position);
         }
@@ -333,6 +342,11 @@ class BulgarianDeclension extends AbstractLanguageDeclension {
                 }
             }
             return value;
+        }
+
+        protected Object readResolve() {
+            this.values.replaceAll((k, v) -> intern(v));
+            return this;
         }
     }
 
@@ -415,7 +429,6 @@ class BulgarianDeclension extends AbstractLanguageDeclension {
     public boolean isArticleInNounFormAutoDerived() {
         return true;
     }
-
 
     // <My/> <Account case="o" article="the"/> must convert into
     // <My case="o" article="the"/> <Account/> for bulgarian

--- a/src/main/java/com/force/i18n/grammar/impl/CatalanDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/CatalanDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -19,27 +19,27 @@ import com.google.common.collect.ImmutableMap;
 
 /**
  * Declension for Catalan language. General rules as following,
- * 
+ *
  * Noun forms : singular &amp; plural
  *       Case : n/a
  *     Gender : masculine, feminine
  *    Article : definite &amp; indefinite; Defined as below,
- *        ---&gt; definite : 
+ *        ---&gt; definite :
  *             Masculine: singular: el (l’), plural: els
  *             Feminine: singular: la (l’) plural: les
- *        ---&gt; indefinite : 
+ *        ---&gt; indefinite :
  *             Masculine: singular: un, plural: uns
  *             Feminine: singular: una, plural: unes
  *Starts with : vowel(includes H), Consonant
  *       Misc : adjectives are only infected in gender and plurality (no case!)
- * 
+ *
  * @author pu.chen
  *
  */
 class CatalanDeclension extends RomanceDeclension {
     public CatalanDeclension(HumanLanguage language) {
-		super(language);
-	}
+        super(language);
+    }
 
     /**
      * Adjective for Catalan. It takes care of gender, plurality(number) and startwith.
@@ -49,7 +49,7 @@ class CatalanDeclension extends RomanceDeclension {
         SINGULAR_FEMININE(LanguageNumber.SINGULAR, LanguageGender.FEMININE, LanguageStartsWith.CONSONANT),
         PLURAL_MASCULINE(LanguageNumber.PLURAL, LanguageGender.MASCULINE, LanguageStartsWith.CONSONANT),
         PLURAL_FEMININE(LanguageNumber.PLURAL, LanguageGender.FEMININE, LanguageStartsWith.CONSONANT),
-        
+
         SINGULAR_MASCULINE_VOWEL(LanguageNumber.SINGULAR, LanguageGender.MASCULINE, LanguageStartsWith.VOWEL),
         SINGULAR_FEMININE_VOWEL(LanguageNumber.SINGULAR, LanguageGender.FEMININE, LanguageStartsWith.VOWEL),
         PLURAL_MASCULINE_VOWEL(LanguageNumber.PLURAL, LanguageGender.MASCULINE, LanguageStartsWith.VOWEL),
@@ -71,23 +71,24 @@ class CatalanDeclension extends RomanceDeclension {
         @Override public LanguageGender getGender() {return this.gender;}
         @Override public LanguageStartsWith getStartsWith() { return startsWith; }
         @Override public LanguagePossessive getPossessive() { return LanguagePossessive.NONE; }
-		@Override
-		public String getKey() {
-			return getNumber().getDbValue() + "-" + getStartsWith().getDbValue() + "-" + getGender().getDbValue();
-		}
-		@Override
-		public void appendJsFormReplacement(Appendable a, String termFormVar, String genderVar, String startsWithVar)
-				throws IOException {
-			a.append(termFormVar+".substr(0,2)+"+genderVar+"+'-'+"+startsWithVar);
-		}
-		
+
+        @Override
+        public String getKey() {
+            return getNumber().getDbValue() + "-" + getStartsWith().getDbValue() + "-" + getGender().getDbValue();
+        }
+
+        @Override
+        public void appendJsFormReplacement(Appendable a, String termFormVar, String genderVar, String startsWithVar)
+                throws IOException {
+            a.append(termFormVar + ".substr(0,2)+" + genderVar + "+'-'+" + startsWithVar);
+        }
     }
 
     protected static class CatalanAdjective extends Adjective {
- 
         private static final long serialVersionUID = 1L;
+
         // The "keys" here are StartsWith, Gender, and Plurality(number)
-        EnumMap<CatalanModifierForm,String> values = new EnumMap<CatalanModifierForm,String>(CatalanModifierForm.class);
+        EnumMap<CatalanModifierForm, String> values = new EnumMap<>(CatalanModifierForm.class);
         private final LanguageStartsWith startsWith;
 
         CatalanAdjective(LanguageDeclension declension, String name, LanguageStartsWith startsWith, LanguagePosition position) {
@@ -113,38 +114,52 @@ class CatalanDeclension extends RomanceDeclension {
             assert form instanceof CatalanModifierForm : "It's not a supported adjective form for Catalan.";
             values.put((CatalanModifierForm)form, intern(value));
         }
+
         @Override
         public boolean validate(String name) {
             return defaultValidate(name, EnumSet.of(CatalanModifierForm.SINGULAR_FEMININE));
         }
+
+        protected Object readResolve() {
+            this.values.replaceAll((k, v) -> intern(v));
+            return this;
+        }
     }
 
     protected static class CatalanArticle extends Article {
-
         private static final long serialVersionUID = 1L;
+
         // The "keys" here are StartsWith, Gender, and Plurality(number)
-        EnumMap<CatalanModifierForm,String> values = new EnumMap<CatalanModifierForm,String>(CatalanModifierForm.class);
+        EnumMap<CatalanModifierForm, String> values = new EnumMap<>(CatalanModifierForm.class);
 
         CatalanArticle(CatalanDeclension declension, String name, LanguageArticle articleType) {
             super(declension, name, articleType);
         }
 
         @Override
-        public Map< ? extends ArticleForm, String> getAllValues() {
+        public Map<? extends ArticleForm, String> getAllValues() {
             return values;
         }
+
         @Override
         public String getString(ArticleForm form) {
             return values.get(form);
         }
+
         @Override
         protected void setString(ArticleForm form, String value) {
             assert form instanceof CatalanModifierForm : "It's not a supported article form for Catalan.";
             values.put((CatalanModifierForm)form, intern(value));
         }
+
         @Override
         public boolean validate(String name) {
             return defaultValidate(name, EnumSet.of(CatalanModifierForm.SINGULAR_FEMININE));
+        }
+
+        protected Object readResolve() {
+            this.values.replaceAll((k, v) -> intern(v));
+            return this;
         }
     }
 
@@ -164,7 +179,6 @@ class CatalanDeclension extends RomanceDeclension {
     public List< ? extends AdjectiveForm> getAdjectiveForms() {
         return ALL_MODIFIER_FORMS;
     }
-
 
     @Override
     public List< ? extends ArticleForm> getArticleForms() {
@@ -188,39 +202,39 @@ class CatalanDeclension extends RomanceDeclension {
     public AdjectiveForm getAdjectiveForm(LanguageStartsWith startsWith, LanguageGender gender, LanguageNumber number,
             LanguageCase _case, LanguageArticle article, LanguagePossessive possessive) {
         if (_case != LanguageCase.NOMINATIVE || article != LanguageArticle.ZERO) {
-        	return null;
+            return null;
         }
 
         switch (startsWith) {
         case CONSONANT:
-            return gender == LanguageGender.MASCULINE ? 
-            		(number.isPlural() ? CatalanModifierForm.PLURAL_MASCULINE : CatalanModifierForm.SINGULAR_MASCULINE)
+            return gender == LanguageGender.MASCULINE ?
+                    (number.isPlural() ? CatalanModifierForm.PLURAL_MASCULINE : CatalanModifierForm.SINGULAR_MASCULINE)
                     : (number.isPlural() ? CatalanModifierForm.PLURAL_FEMININE : CatalanModifierForm.SINGULAR_FEMININE);
         case VOWEL:
-            return gender == LanguageGender.MASCULINE ? (number.isPlural() ? 
-            		CatalanModifierForm.PLURAL_MASCULINE_VOWEL : CatalanModifierForm.SINGULAR_MASCULINE_VOWEL)
+            return gender == LanguageGender.MASCULINE ? (number.isPlural() ?
+                    CatalanModifierForm.PLURAL_MASCULINE_VOWEL : CatalanModifierForm.SINGULAR_MASCULINE_VOWEL)
                     : (number.isPlural() ? CatalanModifierForm.PLURAL_FEMININE_VOWEL : CatalanModifierForm.SINGULAR_FEMININE_VOWEL);
         case SPECIAL: // n/a for Catalan.
         }
 
         return null;
     }
-    
+
     /*  Article : definite & indefinite
-     *        ---> definite : 
+     *        ---> definite :
      *             Masculine: singular: el (l’), plural: els
      *             Feminine: singular: la (l’) plural: les
-     *        ---> indefinite : 
+     *        ---> indefinite :
      *             Masculine: singular: un, plural: uns
      *             Feminine: singular: una, plural: unes
-     */             
+     */
     private static final EnumMap<CatalanModifierForm, String> DEFINITE_ARTICLE =
             new EnumMap<CatalanModifierForm, String>(ImmutableMap.<CatalanModifierForm,String>builder()
                     .put(CatalanModifierForm.SINGULAR_FEMININE, "la ")
                     .put(CatalanModifierForm.SINGULAR_MASCULINE, "el ")
                     .put(CatalanModifierForm.PLURAL_FEMININE, "les ")
                     .put(CatalanModifierForm.PLURAL_MASCULINE, "els ")
-                    
+
                     .put(CatalanModifierForm.SINGULAR_FEMININE_VOWEL, "l'")
                     .put(CatalanModifierForm.SINGULAR_MASCULINE_VOWEL, "l'")
                     .put(CatalanModifierForm.PLURAL_FEMININE_VOWEL, "les ")
@@ -232,7 +246,7 @@ class CatalanDeclension extends RomanceDeclension {
                 .put(CatalanModifierForm.SINGULAR_MASCULINE, "un ")
                 .put(CatalanModifierForm.PLURAL_FEMININE, "unes ")
                 .put(CatalanModifierForm.PLURAL_MASCULINE, "uns ")
-                
+
                 .put(CatalanModifierForm.SINGULAR_FEMININE_VOWEL, "una ")
                 .put(CatalanModifierForm.SINGULAR_MASCULINE_VOWEL, "un ")
                 .put(CatalanModifierForm.PLURAL_FEMININE_VOWEL, "unes ")
@@ -248,11 +262,9 @@ class CatalanDeclension extends RomanceDeclension {
     protected Map< ? extends ArticleForm, String> getIndefiniteArticles() {
         return INDEFINITE_ARTICLE;
     }
-    
+
     @Override
     public Article createArticle(String name, LanguageArticle articleType) {
         return new CatalanArticle(this, name, articleType);
     }
-
-
 }

--- a/src/main/java/com/force/i18n/grammar/impl/ComplexGrammaticalForm.java
+++ b/src/main/java/com/force/i18n/grammar/impl/ComplexGrammaticalForm.java
@@ -7,6 +7,8 @@
 
 package com.force.i18n.grammar.impl;
 
+import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
+
 import java.io.*;
 import java.util.*;
 
@@ -41,10 +43,10 @@ import com.google.common.collect.Multimap;
  * @author stamm
  */
 abstract class ComplexGrammaticalForm implements Serializable, Comparable<ComplexGrammaticalForm> {
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
     private int ordinal;  // The order inside "allNounForms"
-	private transient LanguageDeclension declension;   // this isn't serializable.
+    private transient LanguageDeclension declension;   // this isn't serializable.
 
     protected ComplexGrammaticalForm(LanguageDeclension declension, int ordinal) {
         this.declension = declension;
@@ -72,11 +74,10 @@ abstract class ComplexGrammaticalForm implements Serializable, Comparable<Comple
         return false;
     }
 
-	@Override
-	public int compareTo(ComplexGrammaticalForm o) {
-		return this.getOrdinal() - o.getOrdinal();
-	}
-
+    @Override
+    public int compareTo(ComplexGrammaticalForm o) {
+        return this.getOrdinal() - o.getOrdinal();
+    }
 
     /**
      * Use the serialization proxy for random noun forms (with a 7-ish byte cost)
@@ -90,16 +91,15 @@ abstract class ComplexGrammaticalForm implements Serializable, Comparable<Comple
      * Proxy for ComplexGrammaticalForms to ensure their "Enum" ness
      */
     static class SerializationProxy implements Serializable {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private final short languageOrdinal;
+        private static final long serialVersionUID = 1L;
+
+        private static final List<? extends HumanLanguage> LANGUAGE_ARRAY = LanguageProviderFactory.get().getProvider().getAll();
+        private static final TermType[] TERM_TYPE_ARRAY = TermType.values();
+
+        private final short languageOrdinal;
         private final byte termTypeOrdinal;
         private final byte ordinal;
 
-        private final static List<? extends HumanLanguage> LANGUAGE_ARRAY = LanguageProviderFactory.get().getProvider().getAll();
-        private final static TermType[] TERM_TYPE_ARRAY = TermType.values();
         public SerializationProxy(ComplexGrammaticalForm form) {
             this.languageOrdinal = (short)form.getDeclension().getLanguage().ordinal();
             this.termTypeOrdinal = (byte)form.getTermType().ordinal();
@@ -153,11 +153,9 @@ abstract class ComplexGrammaticalForm implements Serializable, Comparable<Comple
      * @author stamm
      */
     abstract static class ComplexAdjectiveForm extends ComplexGrammaticalForm implements AdjectiveForm {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		protected ComplexAdjectiveForm(LanguageDeclension declension, int ordinal) {
+        private static final long serialVersionUID = 1L;
+
+        protected ComplexAdjectiveForm(LanguageDeclension declension, int ordinal) {
             super(declension, ordinal);
         }
         @Override protected TermType getTermType() { return TermType.Adjective; }
@@ -166,12 +164,12 @@ abstract class ComplexGrammaticalForm implements Serializable, Comparable<Comple
             return getDeclension().getLanguage() + "Adj:" + getOrdinal() + "-" + getNumber().getDbValue() + "-" + getArticle().getDbValue() + "-" + getCase().getDbValue() + "-" + getGender().getDbValue() + "-" + getStartsWith().getDbValue();
         }
         // Assume the
-		@Override
-		public void appendJsFormReplacement(Appendable a, String termFormVar, String genderVar, String startsWithVar)
-				throws IOException {
-			assert getDeclension().hasGender() : "You need to override this for declensions without gender.";
-			a.append(genderVar+"+"+termFormVar+".substr(1)");
-		}
+        @Override
+        public void appendJsFormReplacement(Appendable a, String termFormVar, String genderVar, String startsWithVar)
+                throws IOException {
+            assert getDeclension().hasGender() : "You need to override this for declensions without gender.";
+            a.append(genderVar + "+" + termFormVar + ".substr(1)");
+        }
     }
 
     /**
@@ -179,11 +177,9 @@ abstract class ComplexGrammaticalForm implements Serializable, Comparable<Comple
      * @author stamm
      */
     abstract static class ComplexArticleForm extends ComplexGrammaticalForm implements ArticleForm {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		protected ComplexArticleForm(LanguageDeclension declension, int ordinal) {
+        private static final long serialVersionUID = 1L;
+
+        protected ComplexArticleForm(LanguageDeclension declension, int ordinal) {
             super(declension, ordinal);
         }
         @Override protected TermType getTermType() { return TermType.Article; }
@@ -191,18 +187,19 @@ abstract class ComplexGrammaticalForm implements Serializable, Comparable<Comple
         public String toString() {
             return getDeclension().getLanguage() + "Art" + getOrdinal() + "-" + getKey();
         }
-		@Override
-		public String getKey() {
-			return getGender().getDbValue() + "-" + getNumber().getDbValue() + "-" + getCase().getDbValue() + "-" + getStartsWith().getDbValue();
-		}
 
-		@Override
-		public void appendJsFormReplacement(Appendable a, String termFormVar, String genderVar, String startsWithVar)
-				throws IOException {
-			// TODO: Fix greek's articles to have their own complex article form.
-			assert !getDeclension().hasStartsWith() || getDeclension().getLanguage().getLocale().getLanguage().equals("el"): "You need to override this for declensions with startswith";
-			a.append(genderVar+"+"+termFormVar+".substr(1)");
-		}
+        @Override
+        public String getKey() {
+            return getGender().getDbValue() + "-" + getNumber().getDbValue() + "-" + getCase().getDbValue() + "-" + getStartsWith().getDbValue();
+        }
+
+        @Override
+        public void appendJsFormReplacement(Appendable a, String termFormVar, String genderVar, String startsWithVar)
+                throws IOException {
+            // TODO: Fix greek's articles to have their own complex article form.
+            assert !getDeclension().hasStartsWith() || getDeclension().getLanguage().getLocale().getLanguage().equals("el"): "You need to override this for declensions with startswith";
+            a.append(genderVar+"+"+termFormVar+".substr(1)");
+        }
     }
 
 
@@ -275,7 +272,7 @@ abstract class ComplexGrammaticalForm implements Serializable, Comparable<Comple
         assert formList != null;
         for (int i = 0; i < size; i++) {
             int ordinal = in.readByte();
-            String value = (String) in.readObject();
+            String value = intern((String) in.readObject());
             result.put(formList.get(ordinal), value);
         }
         return result;
@@ -480,23 +477,25 @@ abstract class ComplexGrammaticalForm implements Serializable, Comparable<Comple
      * Abstract class for ComplexAdjective's that handles the quick serialization
      */
     abstract static class ComplexAdjective<T extends ComplexAdjectiveForm> extends Adjective {
-		private static final long serialVersionUID = 1L;
-		// The "keys" here are StartsWith, Gender, and Plurality
-        private transient Map<T, String> values = new HashMap<T, String>();
+        private static final long serialVersionUID = 1L;
 
-		public ComplexAdjective(LanguageDeclension declension, String name,
-				LanguagePosition position) {
-			super(declension, name, position);
-		}
+        // The "keys" here are StartsWith, Gender, and Plurality
+        private transient Map<T, String> values = new HashMap<>();
+
+        protected ComplexAdjective(LanguageDeclension declension, String name, LanguagePosition position) {
+            super(declension, name, position);
+        }
 
         @Override
         public Map< ? extends AdjectiveForm, String> getAllValues() {
             return values;
         }
+
         @Override
         public String getString(AdjectiveForm form) {
             return values.get(form);
         }
+
         @Override
         protected void setString(AdjectiveForm form, String value) {
             values.put(getFormClass().cast(form), value);
@@ -509,27 +508,28 @@ abstract class ComplexGrammaticalForm implements Serializable, Comparable<Comple
             out.defaultWriteObject();
             ComplexGrammaticalForm.serializeFormMap(out, values);
         }
+
         private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
             in.defaultReadObject();
             this.values = ComplexGrammaticalForm.deserializeFormMap(in, getDeclension(), TermType.Adjective);
         }
-
     }
 
     /**
      * Abstract class for ComplexNoun's that handles the quick serialization
      */
     abstract static class ComplexNoun<T extends ComplexNounForm> extends Noun {
-		private static final long serialVersionUID = 1L;
-		// The "keys" here are StartsWith, Gender, and Plurality
-        private transient Map<T, String> values = new HashMap<T, String>();
+        private static final long serialVersionUID = 1L;
+
+        // The "keys" here are StartsWith, Gender, and Plurality
+        private transient Map<T, String> values = new HashMap<>();
 
         ComplexNoun(LanguageDeclension declension, String name, String pluralAlias, NounType type, String entityName, LanguageStartsWith startsWith,
         		LanguageGender gender, String access, boolean isStandardField, boolean isCopiedFromDefault) {
             super(declension, name, pluralAlias, type, entityName, startsWith, gender, access, isStandardField, isCopiedFromDefault);
         }
 
-		protected abstract Class<T> getFormClass();
+        protected abstract Class<T> getFormClass();
 
         @Override
         public Map<T, String> getAllDefinedValues() {
@@ -540,22 +540,26 @@ abstract class ComplexGrammaticalForm implements Serializable, Comparable<Comple
             assert getFormClass().isInstance(form) : "You must provide a correct " + getFormClass() + " noun form for a " + getClass();
             return values.get(form);
         }
+
         @Override
         public void setString(String value, NounForm form) {
             values.put(getFormClass().cast(form), value);
         }
+
         @Override
         public Noun clone() {
         	@SuppressWarnings("unchecked") // Clone not generalized
-			ComplexNoun<T> noun = (ComplexNoun<T>) super.clone();
-            noun.values = new HashMap<T, String>(noun.values);
+            ComplexNoun<T> noun = (ComplexNoun<T>) super.clone();
+            noun.values = new HashMap<>(noun.values);
             return noun;
         }
+
         // Reduce size of noun maps
         private void writeObject(ObjectOutputStream out) throws IOException {
             out.defaultWriteObject();
             ComplexGrammaticalForm.serializeFormMap(out, values);
         }
+
         private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
             in.defaultReadObject();
             this.values = ComplexGrammaticalForm.deserializeFormMap(in, getDeclension(), TermType.Noun);
@@ -567,36 +571,39 @@ abstract class ComplexGrammaticalForm implements Serializable, Comparable<Comple
         }
     }
 
-
     /**
      * Abstract class for ComplexArticledNoun that handles the quick serialization
      * TODO: Get rid of LegacyArticledNoun/fold it into Noun itself.
      */
     abstract static class ComplexArticledNoun<T extends ComplexNounForm> extends LegacyArticledNoun {
-		private static final long serialVersionUID = 1L;
-		// The "keys" here are StartsWith, Gender, and Plurality
-        private transient Map<T, String> values = new HashMap<T,String>();
+        private static final long serialVersionUID = 1L;
+
+        // The "keys" here are StartsWith, Gender, and Plurality
+        private transient Map<T, String> values = new HashMap<>();
 
         ComplexArticledNoun(ArticledDeclension declension, String name, String pluralAlias, NounType type, String entityName, LanguageStartsWith startsWith,
         		LanguageGender gender, String access, boolean isStandardField, boolean isCopiedFromDefault) {
             super(declension, name, pluralAlias, type, entityName, startsWith, gender, access, isStandardField, isCopiedFromDefault);
         }
 
-		protected abstract Class<T> getFormClass();
+        protected abstract Class<T> getFormClass();
 
         @Override
         public Map<? extends NounForm, String> getAllDefinedValues() {
             return values;
         }
+
         @Override
         public String getExactString(NounForm form) {
             assert getFormClass().isInstance(form) : "You must provide a correct " + getFormClass() + " noun form for a " + getClass();
             return values.get(form);
         }
+
         @Override
         public void setString(String value, NounForm form) {
             values.put(getFormClass().cast(form), value);
         }
+
         @Override
         public Noun clone() {
         	@SuppressWarnings("unchecked") // Clone not generalized
@@ -604,15 +611,18 @@ abstract class ComplexGrammaticalForm implements Serializable, Comparable<Comple
             noun.values = new HashMap<T,String>(noun.values);
             return noun;
         }
+
         // Reduce size of noun maps
         private void writeObject(ObjectOutputStream out) throws IOException {
             out.defaultWriteObject();
             ComplexGrammaticalForm.serializeFormMap(out, values);
         }
+
         private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
             in.defaultReadObject();
             this.values = ComplexGrammaticalForm.deserializeFormMap(in, getDeclension(), TermType.Noun);
         }
+
         @Override
         public void makeSkinny() {
             values = makeSkinny(values);

--- a/src/main/java/com/force/i18n/grammar/impl/DravidianDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/DravidianDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2019, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 package com.force.i18n.grammar.impl;
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableList;
  * but do not have articles, starts with, adj/noun agreement, possession.
  *
  * This is generalized from Tamil
- * 
+ *
  * @author cgrabill, stamm
  * @since 1.1
  */
@@ -30,8 +30,8 @@ abstract class DravidianDeclension extends AbstractLanguageDeclension {
 
     private final List<DravidianNounForm> entityForms;
     private final List<DravidianNounForm> fieldForms;
-    
-    public DravidianDeclension(HumanLanguage language) {
+
+    protected DravidianDeclension(HumanLanguage language) {
         super(language);
         // Generate the different forms from subclass methods
         ImmutableList.Builder<DravidianNounForm> entityBuilder = ImmutableList.builder();
@@ -49,12 +49,13 @@ abstract class DravidianDeclension extends AbstractLanguageDeclension {
         this.entityForms = entityBuilder.build();
         this.fieldForms = fieldBuilder.build();
     }
-    
+
     static class DravidianNounForm extends ComplexNounForm {
         private static final long serialVersionUID = 1L;
+
         private final LanguageCase caseType;
         private final LanguageNumber number;
-        
+
         DravidianNounForm(LanguageDeclension declension, LanguageNumber number, LanguageCase caseType, int ordinal) {
             super(declension, ordinal);
             this.number = number;
@@ -65,24 +66,41 @@ abstract class DravidianDeclension extends AbstractLanguageDeclension {
         @Override public LanguageCase getCase() { return caseType; }
         @Override public LanguagePossessive getPossessive() { return LanguagePossessive.NONE; }
         @Override public LanguageArticle getArticle() { return LanguageArticle.ZERO; }
+
         @Override
         public String getKey() {
             return getNumber().getDbValue() + "-" + getCase().getDbValue();
         }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), this.caseType, this.number);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (other instanceof DravidianNounForm) {
+                DravidianNounForm o = this.getClass().cast(other);
+                return super.equals(other) && this.caseType == o.caseType && this.number == o.number;
+            }
+            return false;
+        }
+
         @Override
         public String toString() {
             return "DravNF:" + getKey();
         }
-
     }
-    
+
     /**
      * Represents a Dravidian noun. See DravidianNounForm for more info.
      */
     public static class DravidianNoun extends Noun {
         private static final long serialVersionUID = 1L;
+
         //store everything
-        private transient Map<DravidianNounForm, String> values = new HashMap<DravidianNounForm, String>();
+        private transient Map<DravidianNounForm, String> values = new HashMap<>();
 
         DravidianNoun(DravidianDeclension declension, String name, String pluralAlias, NounType type, String entityName,
                 LanguageGender gender, String access, boolean isStandardField, boolean isCopiedFromDefault ) {
@@ -109,7 +127,7 @@ abstract class DravidianDeclension extends AbstractLanguageDeclension {
         public void makeSkinny() {
             values = makeSkinny(values);
         }
-        
+
         /**
          * Need to override so that a cloned DravidianNoun's values map is a HashMap.
          * Else, if you clone() after makeSkinny() has been called, you won't
@@ -127,12 +145,13 @@ abstract class DravidianDeclension extends AbstractLanguageDeclension {
             assert nid instanceof DravidianNounForm : "Error: Used non-Dravidian noun form to get Dravidian noun.";
             return values.get(nid);
         }
-        
+
         // Override read and write, or else you'll get mysterious exception
         private void writeObject(ObjectOutputStream out) throws IOException {
             out.defaultWriteObject();
             ComplexGrammaticalForm.serializeFormMap(out, values);
         }
+
         private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
             in.defaultReadObject();
             this.values = ComplexGrammaticalForm.deserializeFormMap(in, getDeclension(), TermType.Noun);
@@ -180,7 +199,7 @@ abstract class DravidianDeclension extends AbstractLanguageDeclension {
     public boolean hasGender() {
         return true;
     }
-    
+
     @Override
     public EnumSet<LanguageGender> getRequiredGenders() {
         return EnumSet.of(LanguageGender.NEUTER,
@@ -193,7 +212,7 @@ abstract class DravidianDeclension extends AbstractLanguageDeclension {
     public boolean hasStartsWith() {
         return false;
     }
-    
+
 
     @Override
     public boolean hasArticleInNounForm() {
@@ -203,13 +222,13 @@ abstract class DravidianDeclension extends AbstractLanguageDeclension {
     static final class TamilDeclension extends DravidianDeclension {
         public TamilDeclension(HumanLanguage language) {
             super(language);
-        }        
-        
+        }
+
         @Override
         public EnumSet<LanguageCase> getRequiredCases() {
-            return EnumSet.of(LanguageCase.NOMINATIVE, 
-                              LanguageCase.GENITIVE, 
-                              LanguageCase.ACCUSATIVE, 
+            return EnumSet.of(LanguageCase.NOMINATIVE,
+                              LanguageCase.GENITIVE,
+                              LanguageCase.ACCUSATIVE,
                               LanguageCase.DATIVE,
                               LanguageCase.ABLATIVE,
                               LanguageCase.INSTRUMENTAL,
@@ -223,13 +242,13 @@ abstract class DravidianDeclension extends AbstractLanguageDeclension {
     static final class TeluguDeclension extends DravidianDeclension {
         public TeluguDeclension(HumanLanguage language) {
             super(language);
-        }        
-        
+        }
+
         @Override
         public EnumSet<LanguageCase> getRequiredCases() {
-            return EnumSet.of(LanguageCase.NOMINATIVE, 
-                              LanguageCase.GENITIVE, 
-                              LanguageCase.ACCUSATIVE, 
+            return EnumSet.of(LanguageCase.NOMINATIVE,
+                              LanguageCase.GENITIVE,
+                              LanguageCase.ACCUSATIVE,
                               LanguageCase.DATIVE,
                               LanguageCase.ABLATIVE,  // Ablative & Instrumental merger
                               LanguageCase.LOCATIVE);
@@ -242,13 +261,13 @@ abstract class DravidianDeclension extends AbstractLanguageDeclension {
     static final class KannadaDeclension extends DravidianDeclension {
         public KannadaDeclension(HumanLanguage language) {
             super(language);
-        }        
-        
+        }
+
         @Override
         public EnumSet<LanguageCase> getRequiredCases() {
-            return EnumSet.of(LanguageCase.NOMINATIVE, 
-                              LanguageCase.GENITIVE, 
-                              LanguageCase.ACCUSATIVE,  
+            return EnumSet.of(LanguageCase.NOMINATIVE,
+                              LanguageCase.GENITIVE,
+                              LanguageCase.ACCUSATIVE,
                               LanguageCase.DATIVE,
                               LanguageCase.ABLATIVE,  // Ablative & Instrumental merger
                               LanguageCase.LOCATIVE);
@@ -262,19 +281,18 @@ abstract class DravidianDeclension extends AbstractLanguageDeclension {
     static final class MalayalamDeclension extends DravidianDeclension {
         public MalayalamDeclension(HumanLanguage language) {
             super(language);
-        }        
-        
+        }
+
         @Override
         public EnumSet<LanguageCase> getRequiredCases() {
-            return EnumSet.of(LanguageCase.NOMINATIVE, 
-                              LanguageCase.GENITIVE, 
-                              LanguageCase.ACCUSATIVE,  
+            return EnumSet.of(LanguageCase.NOMINATIVE,
+                              LanguageCase.GENITIVE,
+                              LanguageCase.ACCUSATIVE,
                               LanguageCase.DATIVE,
                               LanguageCase.INSTRUMENTAL,  // Ablative & Instrumental merger
-                              LanguageCase.LOCATIVE);  
+                              LanguageCase.LOCATIVE);
             // TODO FIXME: Malayalam has a "Sociative" case that expresses 'together with'.  It's mostly obsolete in Hungarian, so we don't have it anywhere else.
             // Check with linguists?
         }
-
     }
 }

--- a/src/main/java/com/force/i18n/grammar/impl/EnglishDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/EnglishDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -76,10 +76,11 @@ class EnglishDeclension extends ArticledDeclension {
      * Represents an english adjective
      */
     public static class EnglishArticle extends Article {
+        private static final long serialVersionUID = 597093332610194996L; // javac generated value. Mandatory for javac/eclipse compatibility
+
         private String singular; // We only store one value
         private String singularVowel; // We only store one value
         private String plural; // We only store one value
-        private static final long serialVersionUID = 597093332610194996L; // javac generated value. Mandatory for javac/eclipse compatibility
 
         EnglishArticle(EnglishDeclension declension, String name, LanguageArticle articleType) {
             super(declension, name, articleType);
@@ -125,6 +126,13 @@ class EnglishDeclension extends ArticledDeclension {
                 this.plural = this.singular;
             }
             return true;
+        }
+
+        protected Object readResolve() {
+            this.singular = intern(this.singular);
+            this.singularVowel = intern(this.singularVowel);
+            this.plural = intern(this.plural);
+            return this;
         }
     }
 

--- a/src/main/java/com/force/i18n/grammar/impl/FinnishDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/FinnishDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableSet;
  */
 class FinnishDeclension extends AbstractLanguageDeclension {
     private static final Logger logger = Logger.getLogger(FinnishDeclension.class.getName());
+
     private final List<FinnishNounForm> entityForms;
     private final List<FinnishNounForm> fieldForms;
     private final List<FinnishAdjectiveForm> adjectiveForms;
@@ -57,7 +58,6 @@ class FinnishDeclension extends AbstractLanguageDeclension {
     public boolean hasPossessive() {
         return true;
     }
-
 
     public FinnishDeclension(HumanLanguage language) {
     	super(language);
@@ -94,45 +94,58 @@ class FinnishDeclension extends AbstractLanguageDeclension {
      * Finnish nouns are inflected for case, number, and possessive
      */
     static class FinnishNounForm extends ComplexNounForm {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private final LanguageCase caseType;
-        private final LanguageNumber number;
-        private final LanguagePossessive possesive;
+        private static final long serialVersionUID = 1L;
 
-        public FinnishNounForm(LanguageDeclension declension, LanguageNumber number, LanguageCase caseType, LanguagePossessive possesive, int ordinal) {
+        private final LanguageCase caseType;
+        private final LanguageNumber number;
+        private final LanguagePossessive possessive;
+
+        public FinnishNounForm(LanguageDeclension declension, LanguageNumber number, LanguageCase caseType, LanguagePossessive possessive, int ordinal) {
             super(declension, ordinal);
             this.number = number;
             this.caseType = caseType;
-            this.possesive = possesive;
+            this.possessive = possessive;
         }
 
         @Override public LanguageArticle getArticle() { return LanguageArticle.ZERO; }
         @Override public LanguageCase getCase() {  return this.caseType; }
         @Override public LanguageNumber getNumber() {  return this.number; }
-        @Override public LanguagePossessive getPossessive() { return possesive;}
+        @Override public LanguagePossessive getPossessive() { return possessive;}
+
         @Override
         public String getKey() {
             return getNumber().getDbValue() + "-" + getCase().getDbValue() + "-" + getPossessive().getDbValue();
         }
+
         @Override
         public String toString() {
             return "FinnishNF:"+getKey();
         }
-    }
 
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), this.caseType, this.number, this.possessive);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (other instanceof FinnishNounForm) {
+                FinnishNounForm o = this.getClass().cast(other);
+                return super.equals(other) && this.caseType == o.caseType && this.number == o.number
+                        && this.possessive == o.possessive;
+            }
+            return false;
+        }
+    }
 
     /**
      * Finnish nouns are inflected for case and number
      */
     static class FinnishAdjectiveForm extends ComplexAdjectiveForm {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private final LanguageNumber number;
+        private static final long serialVersionUID = 1L;
+
+        private final LanguageNumber number;
         private final LanguageCase caseType;
 
         public FinnishAdjectiveForm(LanguageDeclension declension, LanguageNumber number, LanguageCase caseType, int ordinal) {
@@ -147,16 +160,32 @@ class FinnishDeclension extends AbstractLanguageDeclension {
         @Override public LanguageStartsWith getStartsWith() {  return LanguageStartsWith.CONSONANT; }
         @Override public LanguageGender getGender() {  return LanguageGender.NEUTER; }
         @Override public LanguagePossessive getPossessive() { return LanguagePossessive.NONE; }
-		@Override
-		public String getKey() {
-			return getNumber().getDbValue() + "-" + getCase().getDbValue();
-		}
 
-		@Override
-		public void appendJsFormReplacement(Appendable a, String termFormVar, String genderVar, String startsWithVar)
-				throws IOException {
-			a.append(termFormVar);
-		}
+        @Override
+        public String getKey() {
+            return getNumber().getDbValue() + "-" + getCase().getDbValue();
+        }
+
+        @Override
+        public void appendJsFormReplacement(Appendable a, String termFormVar, String genderVar, String startsWithVar)
+                throws IOException {
+            a.append(termFormVar);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), this.caseType, this.number);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (other instanceof FinnishAdjectiveForm) {
+                FinnishAdjectiveForm o = this.getClass().cast(other);
+                return super.equals(other) && this.caseType == o.caseType && this.number == o.number;
+            }
+            return false;
+        }
     }
 
     /**
@@ -164,20 +193,22 @@ class FinnishDeclension extends AbstractLanguageDeclension {
      * See FinnishNounForm for more info
      */
     public static class FinnishNoun extends ComplexNoun<FinnishNounForm> {
-		private static final long serialVersionUID = 1L;
-		// Store everything for now.
+        private static final long serialVersionUID = 1L;
 
         FinnishNoun(FinnishDeclension declension, String name, String pluralAlias, NounType type, String entityName, String access, boolean isStandardField, boolean isCopiedFromDefault) {
             super(declension, name, pluralAlias, type, entityName, LanguageStartsWith.CONSONANT, LanguageGender.NEUTER, access, isStandardField, isCopiedFromDefault);
         }
+
         @Override
-		protected final Class<FinnishNounForm> getFormClass() {
-        	return FinnishNounForm.class;
-		}
-		@Override
+        protected final Class<FinnishNounForm> getFormClass() {
+            return FinnishNounForm.class;
+        }
+
+        @Override
         protected boolean validateValues(String name, LanguageCase _case) {
             return defaultValidate(name, getDeclension().getFieldForms());
         }
+
         @Override
         protected boolean validateGender(String name) {
             if (getGender() != LanguageGender.NEUTER) {
@@ -192,15 +223,18 @@ class FinnishDeclension extends AbstractLanguageDeclension {
      * Represents a finnish adjective
      */
     public static class FinnishAdjective extends ComplexAdjective<FinnishAdjectiveForm> {
-		private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
+
         FinnishAdjective(LanguageDeclension declension, String name, LanguagePosition position) {
             super(declension, name, position);
         }
+
         @Override
-		protected final Class<FinnishAdjectiveForm> getFormClass() {
+        protected final Class<FinnishAdjectiveForm> getFormClass() {
         	return FinnishAdjectiveForm.class;
-		}
-		@Override
+        }
+
+        @Override
         public boolean validate(String name) {
             defaultValidate(name, ImmutableSet.of(getDeclension().getAdjectiveForm(LanguageStartsWith.CONSONANT, LanguageGender.NEUTER, LanguageNumber.SINGULAR, LanguageCase.NOMINATIVE, LanguageArticle.ZERO, LanguagePossessive.NONE)));
             return true;
@@ -211,7 +245,6 @@ class FinnishDeclension extends AbstractLanguageDeclension {
     public Adjective createAdjective(String name, LanguageStartsWith startsWith, LanguagePosition position) {
         return new FinnishAdjective(this, name, position);
     }
-
 
     /* (non-Javadoc)
      * @see i18n.grammar.LanguageDeclension#createNoun(i18n.grammar.Noun.NounType, i18n.grammar.LanguageStartsWith, i18n.grammar.LanguageGender, java.lang.String, boolean)
@@ -268,5 +301,4 @@ class FinnishDeclension extends AbstractLanguageDeclension {
                     TERMINATIVE, ESSIVE, ABESSIVE, COMITATIVE);
         }
     }
-
 }

--- a/src/main/java/com/force/i18n/grammar/impl/FrenchDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/FrenchDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -68,12 +68,10 @@ class FrenchDeclension extends RomanceDeclension {
     }
 
     protected static class FrenchAdjective extends Adjective {
-        /**
-		 * 
-		 */
-		private static final long serialVersionUID = 1L;
-		// The "keys" here are StartsWith, Gender, and Plurality
-        EnumMap<FrenchModifierForm,String> values = new EnumMap<FrenchModifierForm,String>(FrenchModifierForm.class);
+        private static final long serialVersionUID = 1L;
+
+        // The "keys" here are StartsWith, Gender, and Plurality
+        EnumMap<FrenchModifierForm, String> values = new EnumMap<>(FrenchModifierForm.class);
         private final LanguageStartsWith startsWith;
 
         FrenchAdjective(LanguageDeclension declension, String name, LanguageStartsWith startsWith, LanguagePosition position) {
@@ -90,28 +88,36 @@ class FrenchDeclension extends RomanceDeclension {
         public Map< ? extends AdjectiveForm, String> getAllValues() {
             return values;
         }
+
         @Override
         public String getString(AdjectiveForm form) {
             return values.get(form);
         }
+
         @Override
         protected void setString(AdjectiveForm form, String value) {
             assert form instanceof FrenchModifierForm : "The french do not like their language sullied with foreign words";
             values.put((FrenchModifierForm)form, intern(value));
         }
+
         @Override
         public boolean validate(String name) {
             return defaultValidate(name, EnumSet.of(FrenchModifierForm.SINGULAR_FEMININE));
         }
+
+        protected Object readResolve() {
+            for (Map.Entry<FrenchModifierForm, String> e : this.values.entrySet()) {
+                this.values.put(e.getKey(), intern(e.getValue()));
+            }
+            return this;
+        }
     }
 
     protected static class FrenchArticle extends Article {
-        /**
-		 * 
-		 */
-		private static final long serialVersionUID = 1L;
-		// The "keys" here are StartsWith, Gender, and Plurality
-        EnumMap<FrenchModifierForm,String> values = new EnumMap<FrenchModifierForm,String>(FrenchModifierForm.class);
+        private static final long serialVersionUID = 1L;
+
+        // The "keys" here are StartsWith, Gender, and Plurality
+        EnumMap<FrenchModifierForm, String> values = new EnumMap<>(FrenchModifierForm.class);
 
         FrenchArticle(FrenchDeclension declension, String name, LanguageArticle articleType) {
             super(declension, name, articleType);
@@ -121,18 +127,28 @@ class FrenchDeclension extends RomanceDeclension {
         public Map< ? extends ArticleForm, String> getAllValues() {
             return values;
         }
+
         @Override
         public String getString(ArticleForm form) {
             return values.get(form);
         }
+
         @Override
         protected void setString(ArticleForm form, String value) {
             assert form instanceof FrenchModifierForm : "The french do not like their language sullied with foreign words";
             values.put((FrenchModifierForm)form, intern(value));
         }
+
         @Override
         public boolean validate(String name) {
             return defaultValidate(name, EnumSet.of(FrenchModifierForm.SINGULAR_FEMININE));
+        }
+
+        protected Object readResolve() {
+            for (Map.Entry<FrenchModifierForm, String> e : this.values.entrySet()) {
+                this.values.put(e.getKey(), intern(e.getValue()));
+            }
+            return this;
         }
     }
 
@@ -152,7 +168,6 @@ class FrenchDeclension extends RomanceDeclension {
     public List< ? extends AdjectiveForm> getAdjectiveForms() {
         return ALL_MODIFIER_FORMS;
     }
-
 
     @Override
     public List< ? extends ArticleForm> getArticleForms() {
@@ -189,7 +204,7 @@ class FrenchDeclension extends RomanceDeclension {
     }
 
     private static final EnumMap<FrenchModifierForm, String> INDEFINITE_ARTICLE =
-        new EnumMap<FrenchModifierForm, String>(ImmutableMap.<FrenchModifierForm,String>builder()
+        new EnumMap<>(ImmutableMap.<FrenchModifierForm,String>builder()
                 .put(FrenchModifierForm.SINGULAR_FEMININE, "une ")
                 .put(FrenchModifierForm.SINGULAR_MASCULINE, "un ")
                 .put(FrenchModifierForm.PLURAL_FEMININE, "des ")
@@ -200,7 +215,7 @@ class FrenchDeclension extends RomanceDeclension {
                 .put(FrenchModifierForm.PLURAL_MASCULINE_V, "des ").build());
 
     private static final EnumMap<FrenchModifierForm, String> DEFINITE_ARTICLE =
-        new EnumMap<FrenchModifierForm, String>(ImmutableMap.<FrenchModifierForm,String>builder()
+        new EnumMap<>(ImmutableMap.<FrenchModifierForm,String>builder()
                 .put(FrenchModifierForm.SINGULAR_FEMININE, "la ")
                 .put(FrenchModifierForm.SINGULAR_MASCULINE, "le ")
                 .put(FrenchModifierForm.PLURAL_FEMININE, "les ")
@@ -230,7 +245,7 @@ class FrenchDeclension extends RomanceDeclension {
 		}
 
 		private static final EnumMap<FrenchModifierForm, String> RM_INDEFINITE_ARTICLE =
-            new EnumMap<FrenchModifierForm, String>(ImmutableMap.<FrenchModifierForm,String>builder()
+            new EnumMap<>(ImmutableMap.<FrenchModifierForm,String>builder()
                     .put(FrenchModifierForm.SINGULAR_FEMININE, "ina ")
                     .put(FrenchModifierForm.SINGULAR_MASCULINE, "in ")
                     .put(FrenchModifierForm.PLURAL_FEMININE, "")
@@ -241,7 +256,7 @@ class FrenchDeclension extends RomanceDeclension {
                     .put(FrenchModifierForm.PLURAL_MASCULINE_V, "").build());
 
         private static final EnumMap<FrenchModifierForm, String> RM_DEFINITE_ARTICLE =
-            new EnumMap<FrenchModifierForm, String>(ImmutableMap.<FrenchModifierForm,String>builder()
+            new EnumMap<>(ImmutableMap.<FrenchModifierForm,String>builder()
                     .put(FrenchModifierForm.SINGULAR_FEMININE, "la ")
                     .put(FrenchModifierForm.SINGULAR_MASCULINE, "il ")
                     .put(FrenchModifierForm.PLURAL_FEMININE, "las ")
@@ -266,6 +281,4 @@ class FrenchDeclension extends RomanceDeclension {
     public Article createArticle(String name, LanguageArticle articleType) {
         return new FrenchArticle(this, name, articleType);
     }
-
-
 }

--- a/src/main/java/com/force/i18n/grammar/impl/GermanicDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/GermanicDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -42,7 +42,7 @@ abstract class GermanicDeclension extends ArticledDeclension {
     private final EnumMap<LanguageArticle,ModifierFormMap<GermanicAdjectiveForm>> adjectiveFormMap;
     private final ModifierFormMap<GermanicArticleForm> articleFormMap;
 
-    public GermanicDeclension(HumanLanguage language) {
+    protected GermanicDeclension(HumanLanguage language) {
     	super(language);
         // Generate the different forms from subclass methods
         ImmutableList.Builder<GermanicNounForm> entityBuilder = ImmutableList.builder();
@@ -91,16 +91,14 @@ abstract class GermanicDeclension extends ArticledDeclension {
             }
         }
         this.articleForms = artBuilder.build();
-        this.articleFormMap = new ModifierFormMap<GermanicArticleForm>(this.articleForms);
+        this.articleFormMap = new ModifierFormMap<>(this.articleForms);
     }
 
 
     static class GermanicNounForm extends ComplexNounForm {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private final LanguageCase caseType;
+        private static final long serialVersionUID = 1L;
+
+        private final LanguageCase caseType;
         private final LanguageNumber number;
         private final LanguageArticle article;
 
@@ -115,6 +113,7 @@ abstract class GermanicDeclension extends ArticledDeclension {
         @Override public LanguageCase getCase() {  return this.caseType; }
         @Override public LanguageNumber getNumber() {  return this.number; }
         @Override public LanguagePossessive getPossessive() { return LanguagePossessive.NONE;}
+
         @Override
         public String getKey() {
             if (((GermanicDeclension)getDeclension()).getRequiredNounArticles().size() > 1) {
@@ -123,18 +122,33 @@ abstract class GermanicDeclension extends ArticledDeclension {
                 return getNumber().getDbValue() + "-" + getCase().getDbValue();
             }
         }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), this.caseType, this.number, this.article);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (other instanceof GermanicNounForm) {
+                GermanicNounForm o = this.getClass().cast(other);
+                return super.equals(other) && this.caseType == o.caseType && this.number == o.number
+                        && this.article == o.article;
+            }
+            return false;
+        }
+
         @Override
         public String toString() {
-            return "GermanicNF:"+getKey();
+            return "GermanicNF:" + getKey();
         }
     }
 
     static class GermanicAdjectiveForm extends ComplexAdjectiveForm {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private final LanguageNumber number;
+        private static final long serialVersionUID = 1L;
+
+        private final LanguageNumber number;
         private final LanguageArticle article;
         private final LanguageCase caseType;
         private final LanguageGender gender;
@@ -155,18 +169,34 @@ abstract class GermanicDeclension extends ArticledDeclension {
         @Override public LanguageStartsWith getStartsWith() {  return this.startsWith; }
         @Override public LanguageGender getGender() {  return this.gender; }
         @Override public LanguagePossessive getPossessive() { return LanguagePossessive.NONE; }
-		@Override
-		public String getKey() {
-			return getGender().getDbValue() + "-" + getNumber().getDbValue() + "-" + getCase().getDbValue() + "-" + getArticle().getDbValue() ;
-		}
+
+        @Override
+        public String getKey() {
+            return getGender().getDbValue() + "-" + getNumber().getDbValue() + "-" + getCase().getDbValue() + "-" + getArticle().getDbValue() ;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), this.number, this.article, this.caseType, this.gender,
+                    this.startsWith);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (other instanceof GermanicAdjectiveForm) {
+                GermanicAdjectiveForm o = this.getClass().cast(other);
+                return super.equals(other) && this.number == o.number && this.article == o.article
+                        && this.caseType == o.caseType && this.gender == o.gender && this.startsWith == o.startsWith;
+            }
+            return false;
+        }
     }
 
     static class GermanicArticleForm extends ComplexArticleForm {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private final LanguageNumber number;
+        private static final long serialVersionUID = 1L;
+
+        private final LanguageNumber number;
         private final LanguageCase caseType;
         private final LanguageGender gender;
         private final LanguageStartsWith startsWith;
@@ -183,6 +213,22 @@ abstract class GermanicDeclension extends ArticledDeclension {
         @Override public LanguageNumber getNumber() {  return this.number; }
         @Override public LanguageStartsWith getStartsWith() {  return this.startsWith; }
         @Override public LanguageGender getGender() {  return this.gender; }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), this.number, this.caseType, this.gender, this.startsWith);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (other instanceof GermanicArticleForm) {
+                GermanicArticleForm o = this.getClass().cast(other);
+                return super.equals(other) && this.number == o.number && this.caseType == o.caseType
+                        && this.gender == o.gender && this.startsWith == o.startsWith;
+            }
+            return false;
+        }
     }
 
     /**
@@ -190,10 +236,8 @@ abstract class GermanicDeclension extends ArticledDeclension {
      * See GermanicNounForm for more info
      */
     public static class GermanicNoun extends ComplexArticledNoun<GermanicNounForm> {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
+
         GermanicNoun(GermanicDeclension declension, String name, String pluralAlias, NounType type, String entityName, LanguageGender gender, String access, boolean isStandardField, boolean isCopiedFromDefault) {
             this(declension, name, pluralAlias, type, entityName, LanguageStartsWith.CONSONANT, gender, access, isStandardField, isCopiedFromDefault);
         }
@@ -202,18 +246,17 @@ abstract class GermanicDeclension extends ArticledDeclension {
             super(declension, name, pluralAlias, type, entityName, startsWith, gender, access, isStandardField, isCopiedFromDefault);
         }
 
-        
         @Override
         protected boolean validateValues(String name, LanguageCase _case) {
             return defaultValidate(name, getDeclension().getFieldForms());
         }
 
         @Override
-		protected final Class<GermanicNounForm> getFormClass() {
-        	return GermanicNounForm.class;
-		}
+        protected final Class<GermanicNounForm> getFormClass() {
+            return GermanicNounForm.class;
+        }
 
-		@Override
+        @Override
         protected boolean validateGender(String name) {
             if (!getDeclension().getRequiredGenders().contains(getGender())) {
                 logger.info(VALIDATION_WARNING_HEADER + name + " invalid gender");
@@ -233,22 +276,18 @@ abstract class GermanicDeclension extends ArticledDeclension {
      * Represents an english adjective
      */
     public static class GermanicAdjective extends ComplexAdjective<GermanicAdjectiveForm> {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
+
         GermanicAdjective(LanguageDeclension declension, String name, LanguagePosition position) {
             super(declension, name, position);
         }
 
+        @Override
+        protected final Class<GermanicAdjectiveForm> getFormClass() {
+            return GermanicAdjectiveForm.class;
+        }
 
         @Override
-		protected final Class<GermanicAdjectiveForm> getFormClass() {
-        	return GermanicAdjectiveForm.class;
-		}
-
-
-		@Override
         public boolean validate(String name) {
             defaultValidate(name, ImmutableSet.of(getDeclension().getAdjectiveForm(LanguageStartsWith.CONSONANT, LanguageGender.NEUTER, LanguageNumber.SINGULAR, LanguageCase.NOMINATIVE, LanguageArticle.ZERO, LanguagePossessive.NONE)));
             return true;
@@ -259,11 +298,9 @@ abstract class GermanicDeclension extends ArticledDeclension {
      * Represents an english adjective
      */
     public static class GermanicArticle extends Article {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private Map<GermanicArticleForm, String> values = new HashMap<GermanicArticleForm,String>();
+        private static final long serialVersionUID = 1L;
+
+        private Map<GermanicArticleForm, String> values = new HashMap<>();
 
         GermanicArticle(ArticledDeclension declension, String name, LanguageArticle articleType) {
             super(declension, name, articleType);
@@ -289,13 +326,18 @@ abstract class GermanicDeclension extends ArticledDeclension {
             defaultValidate(name, ImmutableSet.of(getDeclension().getArticleForm(LanguageStartsWith.CONSONANT, LanguageGender.NEUTER, LanguageNumber.SINGULAR, LanguageCase.NOMINATIVE)));
             return true;
         }
+
+        protected Object readResolve() {
+            this.values.replaceAll((k, v) -> intern(v));
+            return this;
+        }
     }
+
     /**
      * @return the set of articles that the adjectives need to define in the label files.
      * Generally, this would be the zero and definite article for adjective agreement rules
      */
     protected abstract EnumSet<LanguageArticle> getRequiredAdjectiveArticles();
-
 
     private static final EnumSet<LanguageArticle> ZERO_ARTICLES = EnumSet.of(LanguageArticle.ZERO);
     static final EnumSet<LanguageArticle> ZERO_AND_DEFARTICLES = EnumSet.of(LanguageArticle.ZERO, LanguageArticle.DEFINITE);
@@ -312,7 +354,6 @@ abstract class GermanicDeclension extends ArticledDeclension {
     public final boolean hasArticleInNounForm() {
         return getRequiredNounArticles().size() > 1;
     }
-
 
     @Override
     public Adjective createAdjective(String name, LanguageStartsWith startsWith, LanguagePosition position) {
@@ -400,13 +441,12 @@ abstract class GermanicDeclension extends ArticledDeclension {
         return true;
     }
 
-
     static class GermanDeclension extends GermanicDeclension {
         public GermanDeclension(HumanLanguage language) {
             super(language);
             assert language.getLocale().getLanguage().equals("de") : "Initializing a variant german declension for non-german";
-        } 
-        
+        }
+
         private static final Map<LanguageCase, ImmutableMap<LanguageNumber, ImmutableMap<LanguageGender,String>>> DEFINITE_ARTICLE =
             ImmutableMap.of(
                    LanguageCase.NOMINATIVE,
@@ -513,21 +553,21 @@ abstract class GermanicDeclension extends ArticledDeclension {
             }
         }
 
-		@Override
-		public void writeJsonOverrides(Appendable a, String inst) throws IOException {
-			// See above
-			super.writeJsonOverrides(a, inst);
-			a.append(inst + ".formLowercaseNoun = function(value, form) {return value;};");
-		}
+        @Override
+        public void writeJsonOverrides(Appendable a, String inst) throws IOException {
+            // See above
+            super.writeJsonOverrides(a, inst);
+            a.append(inst + ".formLowercaseNoun = function(value, form) {return value;};");
+        }
     }
 
     static class SwedishDeclension extends GermanicDeclension {
         public SwedishDeclension(HumanLanguage language) {
-			super(language);
-	        assert language.getLocale().getLanguage().equals("sv") : "Initializing a language that isn't swedish";
-		}
+            super(language);
+            assert language.getLocale().getLanguage().equals("sv") : "Initializing a language that isn't swedish";
+        }
 
-		public static final LanguageGender EUTER = LanguageGender.FEMININE;
+        public static final LanguageGender EUTER = LanguageGender.FEMININE;
 
         @Override
         protected EnumSet<LanguageArticle> getRequiredAdjectiveArticles() {
@@ -744,26 +784,26 @@ abstract class GermanicDeclension extends ArticledDeclension {
             return EnumSet.of(LanguageGender.NEUTER, LanguageGender.FEMININE, LanguageGender.MASCULINE);
         }
     }
-    
+
     /**
      * Yiddish is Germanic, but with English-style starts-with indefinite articles, and no genitive.
-     * 
-     * 
+     *
+     *
      * Note: The default article in this declension are derived from <a href="https://www.yivo.org/yiddish-alphabet">YIVO standard</a>
-     * , which may differ from the dialect used for a particular community. 
+     * , which may differ from the dialect used for a particular community.
      * Modern Hassidic Yiddish often omits diacritics/niqqud that YIVO uses, and the gender system
      * for the definite article is often simplified to use just "די" regardless of gender for the singular article.
      * If so desired, implement the appropriate Article tag in the names.xml to override these defaults
-     * 
+     *
      * @see https://en.wikipedia.org/wiki/Yiddish_grammar
      */
     static class YiddishDeclension extends GermanicDeclension {
         static EnumSet<LanguageStartsWith> STARTS_WITH = EnumSet.of(LanguageStartsWith.CONSONANT, LanguageStartsWith.VOWEL);
-        
+
         public YiddishDeclension(HumanLanguage language) {
             super(language);
-        } 
-        
+        }
+
         private static final Map<LanguageCase, ImmutableMap<LanguageGender,String>> DEFINITE_ARTICLE =
             ImmutableMap.of(
                    LanguageCase.NOMINATIVE,
@@ -804,7 +844,7 @@ abstract class GermanicDeclension extends ArticledDeclension {
                 return null;
             }
         }
-        
+
         @Override
         public Noun createNoun(String name, String pluralAlias, NounType type, String entityName, LanguageStartsWith startsWith, LanguageGender gender, String access, boolean isStandardField, boolean isCopied) {
             return new GermanicNoun(this, name, pluralAlias, type, entityName, startsWith, gender, access, isStandardField, isCopied);
@@ -823,7 +863,7 @@ abstract class GermanicDeclension extends ArticledDeclension {
         // Like english, it has a "startsWith" for indefinite articles.
         @Override
         public EnumSet<LanguageStartsWith> getRequiredStartsWith() {
-            return STARTS_WITH; 
+            return STARTS_WITH;
         }
 
         @Override

--- a/src/main/java/com/force/i18n/grammar/impl/GreekDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/GreekDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -96,13 +96,9 @@ class GreekDeclension extends GermanicDeclension {
                                );
 
     public static class GreekNoun extends GermanicNoun {
+        private static final long serialVersionUID = 1L;
 
-        /**
-		 * 
-		 */
-		private static final long serialVersionUID = 1L;
-
-		public GreekNoun(GermanicDeclension declension, String name, String pluralAlias, NounType type, String entityName,
+        public GreekNoun(GermanicDeclension declension, String name, String pluralAlias, NounType type, String entityName,
                 LanguageGender gender, String access, boolean isStandardField, boolean isCopied) {
             super(declension, name, pluralAlias, type, entityName, gender, access, isStandardField, isCopied);
         }
@@ -114,7 +110,6 @@ class GreekDeclension extends GermanicDeclension {
                 setStartsWith(startsWithGreekPlosive(value) ? LanguageStartsWith.SPECIAL : LanguageStartsWith.CONSONANT);
             }
         }
-
     }
 
     @Override
@@ -182,9 +177,9 @@ class GreekDeclension extends GermanicDeclension {
     public EnumSet<LanguageGender> getRequiredGenders() {
         return EnumSet.of(LanguageGender.NEUTER, LanguageGender.FEMININE, LanguageGender.MASCULINE);
     }
-    
+
     @Override
     public String formLowercaseNounForm(String s, NounForm form) {
         return hasCapitalization() ? (s == null ? null : s.toLowerCase()) : s;
-    } 
+    }
 }

--- a/src/main/java/com/force/i18n/grammar/impl/HebrewDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/HebrewDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -32,7 +32,7 @@ class HebrewDeclension extends SemiticDeclension {
 		super(language);
 	}
 
-	private static final Logger logger = Logger.getLogger(HebrewDeclension.class.getName());
+    private static final Logger logger = Logger.getLogger(HebrewDeclension.class.getName());
 
     public static enum HebrewNounForm implements NounForm {
         SINGULAR(LanguageNumber.SINGULAR, LanguageArticle.ZERO),
@@ -102,11 +102,9 @@ class HebrewDeclension extends SemiticDeclension {
     private static final String DEFAULT_DEFINITE_PREFIX = "\u05d4";  // ה
 
     public static final class HebrewNoun extends LegacyArticledNoun {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private String singular;
+        private static final long serialVersionUID = 1L;
+
+        private String singular;
         private String plural;
         private String singular_def;
         private String plural_def;
@@ -124,16 +122,19 @@ class HebrewDeclension extends SemiticDeclension {
             return enumMapFilterNulls(HebrewNounForm.SINGULAR, singular, HebrewNounForm.PLURAL, plural, HebrewNounForm.SINGULAR_DEF, singular_def,
                     HebrewNounForm.PLURAL_DEF, plural_def);
         }
+
         @Override
         public String getDefaultString(boolean isPlural) {
             return isPlural ? (plural != null ? plural : singular) : singular;
         }
+
         @Override
         public String getExactString(NounForm form) {
             assert form instanceof HebrewNounForm : "It's not kosher to pass in a non-hebrew noun " + form;
             return form.getArticle() == LanguageArticle.DEFINITE ? form.getNumber() == LanguageNumber.PLURAL ? plural_def : singular_def
                     : form.getNumber() == LanguageNumber.PLURAL ? plural : singular;
         }
+
         @Override
         public void setString(String value, NounForm form) {
             if (form.getArticle() == LanguageArticle.DEFINITE) {
@@ -150,6 +151,7 @@ class HebrewDeclension extends SemiticDeclension {
                 }
             }
         }
+
         @Override
         protected boolean validateValues(String name, LanguageCase _case) {
             if (this.singular == null) {
@@ -172,31 +174,44 @@ class HebrewDeclension extends SemiticDeclension {
             }
             return true;
         }
+
+        @Override
+        protected Object readResolve() {
+            super.readResolve();
+            this.singular = intern(this.singular);
+            this.plural = intern(this.plural);
+            this.singular_def = intern(this.singular_def);
+            this.plural_def = intern(this.plural_def);
+            return this;
+        }
     }
 
     protected static class HebrewAdjective extends Adjective {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		// The "keys" here are StartsWith, Gender, and Plurality
-        EnumMap<HebrewModifierForm,String> values = new EnumMap<HebrewModifierForm,String>(HebrewModifierForm.class);
+        private static final long serialVersionUID = 1L;
+
+        // The "keys" here are StartsWith, Gender, and Plurality
+        EnumMap<HebrewModifierForm, String> values = new EnumMap<>(HebrewModifierForm.class);
+
         HebrewAdjective(LanguageDeclension declension, String name, LanguagePosition position) {
             super(declension, name, position);
         }
+
         @Override
         public Map< ? extends AdjectiveForm, String> getAllValues() {
             return values;
         }
+
         @Override
         public String getString(AdjectiveForm form) {
             return values.get(form);
         }
+
         @Override
         protected void setString(AdjectiveForm form, String value) {
             assert form instanceof HebrewModifierForm : "Enough of this mishegas, ask only for hebrew";
             values.put((HebrewModifierForm)form, intern(value));
         }
+
         @Override
         protected String deriveDefaultString(AdjectiveForm form, String value, AdjectiveForm baseFormed) {
             if (form.getArticle() == LanguageArticle.DEFINITE && baseFormed.getArticle() != LanguageArticle.DEFINITE) {
@@ -208,6 +223,11 @@ class HebrewDeclension extends SemiticDeclension {
         @Override
         public boolean validate(String name) {
             return defaultValidate(name, REQUIRED_ADJECTIVE_FORMS);
+        }
+
+        protected Object readResolve() {
+            this.values.replaceAll((k, v) -> intern(v));
+            return this;
         }
     }
 

--- a/src/main/java/com/force/i18n/grammar/impl/HindiUrduDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/HindiUrduDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -21,7 +21,7 @@ import com.google.common.collect.ImmutableList;
  * Represents the declension of Hindi or Urdu, Indo-Iranian languages which
  * have case, gender, number, and complicated post-positions that attach to the noun
  * aggutinatively.
- * 
+ *
  * We support two of each kind of value to support 4 noun and 8 adjective forms.
  *
  * NOTE: We are reusing Nominative and Objective to represent Direct and Oblique,
@@ -69,15 +69,15 @@ class HindiUrduDeclension extends AbstractLanguageDeclension {
         @Override public LanguageGender getGender() {return this.gender;}
         @Override public LanguageStartsWith getStartsWith() { return LanguageStartsWith.CONSONANT; }
         @Override public LanguagePossessive getPossessive() { return LanguagePossessive.NONE; }
-		@Override
-		public String getKey() {
-			return getGender().getDbValue() + "-" + getCase().getDbValue() + "-" + getNumber().getDbValue();
-		}
-		@Override
-		public void appendJsFormReplacement(Appendable a, String termFormVar, String genderVar, String startsWithVar)
-				throws IOException {
+        @Override
+        public String getKey() {
+            return getGender().getDbValue() + "-" + getCase().getDbValue() + "-" + getNumber().getDbValue();
+        }
+        @Override
+        public void appendJsFormReplacement(Appendable a, String termFormVar, String genderVar, String startsWithVar)
+                throws IOException {
 			a.append(genderVar+"+"+termFormVar+".substr(1)");
-		}
+        }
     }
 
     public static enum HindiUrduNounForm implements NounForm {
@@ -105,11 +105,9 @@ class HindiUrduDeclension extends AbstractLanguageDeclension {
     }
 
     public static final class HindiUrduNoun extends Noun {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private String singular;
+        private static final long serialVersionUID = 1L;
+
+        private String singular;
         private String plural;
         private String singular_obl;
         private String plural_obl;
@@ -127,16 +125,19 @@ class HindiUrduDeclension extends AbstractLanguageDeclension {
             return enumMapFilterNulls(HindiUrduNounForm.SINGULAR, singular, HindiUrduNounForm.PLURAL, plural, HindiUrduNounForm.SINGULAR_OBL, singular_obl,
                     HindiUrduNounForm.PLURAL_OBL, plural_obl);
         }
+
         @Override
         public String getDefaultString(boolean isPlural) {
             return isPlural ? (plural != null ? plural : singular) : singular;
         }
+
         @Override
         public String getString(NounForm form) {
             assert form instanceof HindiUrduNounForm : "Why not hindustani for " + form;
             return form.getCase() == OBLIQUE_CASE ? form.getNumber() == LanguageNumber.PLURAL ? plural_obl : singular_obl
                     : form.getNumber() == LanguageNumber.PLURAL ? plural : singular;
         }
+
         @Override
         public void setString(String value, NounForm form) {
             if (form.getCase() == OBLIQUE_CASE) {
@@ -153,6 +154,7 @@ class HindiUrduDeclension extends AbstractLanguageDeclension {
                 }
             }
         }
+
         @Override
         protected boolean validateValues(String name, LanguageCase _case) {
             if (this.singular == null) {
@@ -174,33 +176,51 @@ class HindiUrduDeclension extends AbstractLanguageDeclension {
             }
             return true;
         }
+
+        @Override
+        protected Object readResolve() {
+            super.readResolve();
+            this.singular = intern(this.singular);
+            this.plural = intern(this.plural);
+            this.singular_obl = intern(this.singular_obl);
+            this.plural_obl = intern(this.plural_obl);
+            return this;
+        }
     }
 
     static class HindiUrduAdjective extends Adjective {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		EnumMap<HindiUrduModifierForm,String> values = new EnumMap<HindiUrduModifierForm,String>(HindiUrduModifierForm.class);
+        private static final long serialVersionUID = 1L;
+
+        EnumMap<HindiUrduModifierForm,String> values = new EnumMap<>(HindiUrduModifierForm.class);
+
         HindiUrduAdjective(LanguageDeclension declension, String name, LanguagePosition position) {
             super(declension, name, position);
         }
+
         @Override
         public Map< ? extends AdjectiveForm, String> getAllValues() {
             return values;
         }
+
         @Override
         public String getString(AdjectiveForm form) {
             return values.get(form);
         }
+
         @Override
         protected void setString(AdjectiveForm form, String value) {
             assert form instanceof HindiUrduModifierForm : "Why not Hindustani?";
             values.put((HindiUrduModifierForm)form, intern(value));
         }
+
         @Override
         public boolean validate(String name) {
             return defaultValidate(name, EnumSet.of(HindiUrduModifierForm.SINGULAR_FEMININE));
+        }
+
+        protected Object readResolve() {
+            this.values.replaceAll((k, v) -> intern(v));
+            return this;
         }
     }
 

--- a/src/main/java/com/force/i18n/grammar/impl/HungarianDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/HungarianDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -95,29 +95,45 @@ class HungarianDeclension extends ArticledDeclension {
      * Hungarian nouns are inflected for case, number, and possessive
      */
     static class HungarianNounForm extends ComplexNounForm {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private final LanguageCase caseType;
-        private final LanguageNumber number;
-        private final LanguagePossessive possesive;
+        private static final long serialVersionUID = 1L;
 
-        public HungarianNounForm(LanguageDeclension declension, LanguageNumber number, LanguageCase caseType, LanguagePossessive possesive, int ordinal) {
+        private final LanguageCase caseType;
+        private final LanguageNumber number;
+        private final LanguagePossessive possessive;
+
+        public HungarianNounForm(LanguageDeclension declension, LanguageNumber number, LanguageCase caseType, LanguagePossessive possessive, int ordinal) {
             super(declension, ordinal);
             this.number = number;
             this.caseType = caseType;
-            this.possesive = possesive;
+            this.possessive = possessive;
         }
 
         @Override public LanguageArticle getArticle() { return LanguageArticle.ZERO; }
         @Override public LanguageCase getCase() {  return this.caseType; }
         @Override public LanguageNumber getNumber() {  return this.number; }
-        @Override public LanguagePossessive getPossessive() { return possesive;}
+        @Override public LanguagePossessive getPossessive() { return possessive;}
+
         @Override
         public String getKey() {
             return getNumber().getDbValue() + "-" + getCase().getDbValue() + "-" + getPossessive().getDbValue();
         }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), this.caseType, this.number, this.possessive);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (other instanceof HungarianNounForm) {
+                HungarianNounForm o = this.getClass().cast(other);
+                return super.equals(other) && this.caseType == o.caseType && this.number == o.number
+                        && this.possessive == o.possessive;
+            }
+            return false;
+        }
+
         @Override
         public String toString() {
             return "HungarianNF:"+getKey();
@@ -128,7 +144,7 @@ class HungarianDeclension extends ArticledDeclension {
      * The Hungarian articles are distinguished by whether the next noun starts with a vowel
      * sound or not (it only matters for the definite article, "a" vs "az" which is similar to a vs an in english)
      */
-    public static enum HungarianArticleForm implements ArticleForm {
+    public enum HungarianArticleForm implements ArticleForm {
         SINGULAR(LanguageNumber.SINGULAR, LanguageStartsWith.CONSONANT),
         SINGULAR_V(LanguageNumber.SINGULAR, LanguageStartsWith.VOWEL),
         PLURAL(LanguageNumber.PLURAL, LanguageStartsWith.CONSONANT),
@@ -151,17 +167,17 @@ class HungarianDeclension extends ArticledDeclension {
                     (form.getStartsWith() == LanguageStartsWith.VOWEL ? SINGULAR_V : SINGULAR)
                     : (form.getStartsWith() == LanguageStartsWith.VOWEL ? PLURAL_V : PLURAL);
         }
-		@Override
-		public String getKey() {
-			return getStartsWith().getDbValue() + "-" + getNumber().getDbValue();
-		}
 
-		@Override
-		public void appendJsFormReplacement(Appendable a, String termFormVar, String genderVar, String startsWithVar)
-				throws IOException {
-			a.append(startsWithVar+"+"+termFormVar+".substr(1)");
-		}
+        @Override
+        public String getKey() {
+            return getStartsWith().getDbValue() + "-" + getNumber().getDbValue();
+        }
 
+        @Override
+        public void appendJsFormReplacement(Appendable a, String termFormVar, String genderVar, String startsWithVar)
+                throws IOException {
+            a.append(startsWithVar + "+" + termFormVar + ".substr(1)");
+        }
     }
 
 
@@ -170,20 +186,18 @@ class HungarianDeclension extends ArticledDeclension {
      * See HungarianNounForm for more info
      */
     public static class HungarianNoun extends ComplexArticledNoun<HungarianNounForm> {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
+
         HungarianNoun(HungarianDeclension declension, String name, String pluralAlias, NounType type, String entityName, LanguageStartsWith startsWith, String access, boolean isStandardField, boolean isCopiedFromDefault) {
             super(declension, name, pluralAlias, type, entityName, startsWith, LanguageGender.NEUTER, access, isStandardField, isCopiedFromDefault);
         }
-        
-        @Override
-		protected final Class<HungarianNounForm> getFormClass() {
-        	return HungarianNounForm.class;
-		}
 
-		@Override
+        @Override
+        protected final Class<HungarianNounForm> getFormClass() {
+            return HungarianNounForm.class;
+        }
+
+        @Override
         protected boolean validateValues(String name, LanguageCase _case) {
             return defaultValidate(name, getDeclension().getFieldForms());
         }
@@ -194,37 +208,44 @@ class HungarianDeclension extends ArticledDeclension {
                 logger.info(VALIDATION_WARNING_HEADER + name + " must be neuter");
             return super.validateGender(name);  // Let it go
         }
-
     }
 
     /**
      * Represents a hungarian adjective
      */
     public static class HungarianArticle extends Article {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private Map<HungarianArticleForm, String> values = new HashMap<HungarianArticleForm,String>();
+        private static final long serialVersionUID = 1L;
+
+        private Map<HungarianArticleForm, String> values = new HashMap<>();
+
         HungarianArticle(ArticledDeclension declension, String name, LanguageArticle articleType) {
             super(declension, name, articleType);
         }
+
         @Override
         public Map<? extends ArticleForm, String> getAllValues() {
             return values;
         }
+
         @Override
         public String getString(ArticleForm form) {
             return values.get(form);
         }
+
         @Override
         protected void setString(ArticleForm form, String value) {
             values.put((HungarianArticleForm)form, intern(value));
         }
+
         @Override
         public boolean validate(String name) {
             defaultValidate(name, ImmutableSet.of(getDeclension().getArticleForm(LanguageStartsWith.CONSONANT, LanguageGender.NEUTER, LanguageNumber.SINGULAR, LanguageCase.NOMINATIVE)));
             return true;
+        }
+
+        protected Object readResolve() {
+            this.values.replaceAll((k, v) -> intern(v));
+            return this;
         }
     }
 

--- a/src/main/java/com/force/i18n/grammar/impl/IndoAryanDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/IndoAryanDeclension.java
@@ -1,38 +1,18 @@
-/* 
+/*
  * Copyright (c) 2019, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 package com.force.i18n.grammar.impl;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.List;
+import java.util.*;
 import java.util.logging.Logger;
 
 import com.force.i18n.HumanLanguage;
-import com.force.i18n.grammar.AbstractLanguageDeclension;
-import com.force.i18n.grammar.Adjective;
-import com.force.i18n.grammar.AdjectiveForm;
-import com.force.i18n.grammar.LanguageArticle;
-import com.force.i18n.grammar.LanguageCase;
-import com.force.i18n.grammar.LanguageDeclension;
-import com.force.i18n.grammar.LanguageGender;
-import com.force.i18n.grammar.LanguageNumber;
-import com.force.i18n.grammar.LanguagePosition;
-import com.force.i18n.grammar.LanguagePossessive;
-import com.force.i18n.grammar.LanguageStartsWith;
-import com.force.i18n.grammar.Noun;
+import com.force.i18n.grammar.*;
 import com.force.i18n.grammar.Noun.NounType;
-import com.force.i18n.grammar.NounForm;
-import com.force.i18n.grammar.impl.ComplexGrammaticalForm.ComplexAdjective;
-import com.force.i18n.grammar.impl.ComplexGrammaticalForm.ComplexAdjectiveForm;
-import com.force.i18n.grammar.impl.ComplexGrammaticalForm.ComplexNoun;
-import com.force.i18n.grammar.impl.ComplexGrammaticalForm.ComplexNounForm;
-import com.force.i18n.grammar.impl.ComplexGrammaticalForm.ModifierFormMap;
-import com.force.i18n.grammar.impl.ComplexGrammaticalForm.NounFormMap;
+import com.force.i18n.grammar.impl.ComplexGrammaticalForm.*;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -43,7 +23,7 @@ import com.google.common.collect.ImmutableSet;
  * As pointed out in the wiki article, there's a popularity in studying German
  * among Marathi native speakers, due to the similarities in the grammar.  Hence
  * the implementation is a lot like an article-less German.
- * 
+ *
  * @see <a href="https://en.wikipedia.org/wiki/Indo-Aryan_languages">Wikipedia: Indo-Aryan languages</a>
  * @see <a href="https://en.wikipedia.org/wiki/Gujarati_grammar#Nouns">Wikipedia: Gujarati Nouns</a>
  * @see <a href="https://en.wikipedia.org/wiki/Marathi_grammar#Nominals">Wikipedia: Marathi Nouns</a>
@@ -91,9 +71,9 @@ abstract class IndoAryanDeclension extends AbstractLanguageDeclension {
         this.adjectiveFormMap = new ModifierFormMap<>(this.adjectiveForms);
     }
 
-
     static class IndoAryanNounForm extends ComplexNounForm {
         private static final long serialVersionUID = 1L;
+
         private final LanguageCase caseType;
         private final LanguageNumber number;
 
@@ -107,10 +87,27 @@ abstract class IndoAryanDeclension extends AbstractLanguageDeclension {
         @Override public LanguageCase getCase() {  return this.caseType; }
         @Override public LanguageNumber getNumber() {  return this.number; }
         @Override public LanguagePossessive getPossessive() { return LanguagePossessive.NONE;}
+
         @Override
         public String getKey() {
             return getNumber().getDbValue() + "-" + getCase().getDbValue();
         }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), this.caseType, this.number);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (other instanceof IndoAryanNounForm) {
+                IndoAryanNounForm o = this.getClass().cast(other);
+                return super.equals(other) && this.caseType == o.caseType && this.number == o.number;
+            }
+            return false;
+        }
+
         @Override
         public String toString() {
             return "IndoAryanNF:"+getKey();
@@ -119,6 +116,7 @@ abstract class IndoAryanDeclension extends AbstractLanguageDeclension {
 
     static class IndoAryanAdjectiveForm extends ComplexAdjectiveForm {
         private static final long serialVersionUID = 1L;
+
         private final LanguageNumber number;
         private final LanguageCase caseType;
         private final LanguageGender gender;
@@ -140,18 +138,31 @@ abstract class IndoAryanDeclension extends AbstractLanguageDeclension {
         public String getKey() {
             return getGender().getDbValue() + "-" + getNumber().getDbValue() + "-" + getCase().getDbValue();
         }
-    }
 
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), this.number, this.caseType, this.gender);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (other instanceof IndoAryanAdjectiveForm) {
+                IndoAryanAdjectiveForm o = this.getClass().cast(other);
+                return super.equals(other) && this.number == o.number && this.caseType == o.caseType
+                        && this.gender == o.gender;
+            }
+            return false;
+        }
+    }
 
     /**
      * Represents an IndoAryan noun.
      * See IndoAryanNounForm for more info
      */
     public static class IndoAryanNoun extends ComplexNoun<IndoAryanNounForm> {
-        /**
-         *
-         */
         private static final long serialVersionUID = 1L;
+
         IndoAryanNoun(IndoAryanDeclension declension, String name, String pluralAlias, NounType type, String entityName, LanguageGender gender, String access, boolean isStandardField, boolean isCopiedFromDefault) {
             super(declension, name, pluralAlias, type, entityName, LanguageStartsWith.CONSONANT, gender, access, isStandardField, isCopiedFromDefault);
         }
@@ -181,16 +192,15 @@ abstract class IndoAryanDeclension extends AbstractLanguageDeclension {
      */
     public static class IndoAryanAdjective extends ComplexAdjective<IndoAryanAdjectiveForm> {
         private static final long serialVersionUID = 1L;
+
         IndoAryanAdjective(LanguageDeclension declension, String name, LanguagePosition position) {
             super(declension, name, position);
         }
-
 
         @Override
         protected final Class<IndoAryanAdjectiveForm> getFormClass() {
             return IndoAryanAdjectiveForm.class;
         }
-
 
         @Override
         public boolean validate(String name) {
@@ -261,18 +271,17 @@ abstract class IndoAryanDeclension extends AbstractLanguageDeclension {
     public boolean hasStartsWith() {
         return false;
     }
-    
+
     @Override
     public EnumSet<LanguageGender> getRequiredGenders() {
         return EnumSet.of(LanguageGender.NEUTER, LanguageGender.FEMININE, LanguageGender.MASCULINE);
     }
 
-    
     static final class GujaratiDeclension extends IndoAryanDeclension {
         public GujaratiDeclension(HumanLanguage language) {
             super(language);
         }
-        
+
         @Override
         public EnumSet<LanguageCase> getRequiredCases() {
             return EnumSet.of(LanguageCase.NOMINATIVE, LanguageCase.OBJECTIVE, LanguageCase.LOCATIVE);  // TODO: Locative is questionable.
@@ -283,15 +292,15 @@ abstract class IndoAryanDeclension extends AbstractLanguageDeclension {
         public MarathiDeclension(HumanLanguage language) {
             super(language);
         }
-        
+
         // https://en.wikipedia.org/wiki/Marathi_grammar#Nominals
         // This needs more study.  In the meantime, I'm making it too many
         @Override
         public EnumSet<LanguageCase> getRequiredCases() {
-            return EnumSet.of(LanguageCase.NOMINATIVE, LanguageCase.ACCUSATIVE, LanguageCase.INSTRUMENTAL, LanguageCase.DATIVE, LanguageCase.ABLATIVE, LanguageCase.GENITIVE, LanguageCase.LOCATIVE); 
+            return EnumSet.of(LanguageCase.NOMINATIVE, LanguageCase.ACCUSATIVE, LanguageCase.INSTRUMENTAL, LanguageCase.DATIVE, LanguageCase.ABLATIVE, LanguageCase.GENITIVE, LanguageCase.LOCATIVE);
         }
     }
-    
+
     // https://en.wikipedia.org/wiki/Punjabi_grammar
     // Nominitive = direct
     // Accusative = oblique
@@ -299,11 +308,10 @@ abstract class IndoAryanDeclension extends AbstractLanguageDeclension {
         public PunjabiDeclension(HumanLanguage language) {
             super(language);
         }
-        
+
         @Override
         public EnumSet<LanguageCase> getRequiredCases() {
-            return EnumSet.of(LanguageCase.NOMINATIVE, LanguageCase.ACCUSATIVE, LanguageCase.INSTRUMENTAL, LanguageCase.ABLATIVE, LanguageCase.VOCATIVE); 
+            return EnumSet.of(LanguageCase.NOMINATIVE, LanguageCase.ACCUSATIVE, LanguageCase.INSTRUMENTAL, LanguageCase.ABLATIVE, LanguageCase.VOCATIVE);
         }
     }
-
 }

--- a/src/main/java/com/force/i18n/grammar/impl/ItalianDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/ItalianDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -60,25 +60,23 @@ class ItalianDeclension extends RomanceDeclension {
         @Override public LanguageGender getGender() {return this.gender;}
         @Override public LanguageStartsWith getStartsWith() { return startsWith; }
         @Override public LanguagePossessive getPossessive() { return LanguagePossessive.NONE; }
-		@Override
-		public String getKey() {
-			return getNumber().getDbValue() + "-" + getGender().getDbValue() + "-" + getStartsWith().getDbValue();
-		}
-		
-		@Override
-		public void appendJsFormReplacement(Appendable a, String termFormVar, String genderVar, String startsWithVar)
-				throws IOException {
+        @Override
+        public String getKey() {
+            return getNumber().getDbValue() + "-" + getGender().getDbValue() + "-" + getStartsWith().getDbValue();
+        }
+
+        @Override
+        public void appendJsFormReplacement(Appendable a, String termFormVar, String genderVar, String startsWithVar)
+                throws IOException {
 			a.append(termFormVar+".substr(0,2)+"+genderVar+"+'-'+"+startsWithVar);
-		}
+        }
     }
 
     protected static class ItalianAdjective extends Adjective {
-        /**
-		 * 
-		 */
-		private static final long serialVersionUID = 1L;
-		// The "keys" here are StartsWith, Gender, and Plurality
-        private final EnumMap<ItalianModifierForm,String> values = new EnumMap<ItalianModifierForm,String>(ItalianModifierForm.class);
+        private static final long serialVersionUID = 1L;
+
+        // The "keys" here are StartsWith, Gender, and Plurality
+        private final EnumMap<ItalianModifierForm, String> values = new EnumMap<>(ItalianModifierForm.class);
         private final LanguageStartsWith startsWith;
 
         ItalianAdjective(LanguageDeclension declension, String name, LanguageStartsWith startsWith, LanguagePosition position) {
@@ -107,20 +105,22 @@ class ItalianDeclension extends RomanceDeclension {
             values.put((ItalianModifierForm)form, intern(value));
         }
 
-
         @Override
         public boolean validate(String name) {
             return defaultValidate(name, EnumSet.of(ItalianModifierForm.SINGULAR_FEMININE));
         }
+
+        protected Object readResolve() {
+            this.values.replaceAll((k, v) -> intern(v));
+            return this;
+        }
     }
 
     protected static class ItalianArticle extends Article {
-        /**
-		 * 
-		 */
-		private static final long serialVersionUID = 1L;
-		// The "keys" here are StartsWith, Gender, and Plurality
-        EnumMap<ItalianModifierForm,String> values = new EnumMap<ItalianModifierForm,String>(ItalianModifierForm.class);
+        private static final long serialVersionUID = 1L;
+
+        // The "keys" here are StartsWith, Gender, and Plurality
+        EnumMap<ItalianModifierForm,String> values = new EnumMap<>(ItalianModifierForm.class);
 
         ItalianArticle(ItalianDeclension declension, String name, LanguageArticle articleType) {
             super(declension, name, articleType);
@@ -142,10 +142,14 @@ class ItalianDeclension extends RomanceDeclension {
             values.put((ItalianModifierForm)form, intern(value));
         }
 
-
         @Override
         public boolean validate(String name) {
             return defaultValidate(name, EnumSet.of(ItalianModifierForm.SINGULAR_FEMININE));
+        }
+
+        protected Object readResolve() {
+            this.values.replaceAll((k, v) -> intern(v));
+            return this;
         }
     }
 
@@ -204,7 +208,7 @@ class ItalianDeclension extends RomanceDeclension {
     }
 
     private static final EnumMap<ItalianModifierForm, String> DEFINITE_ARTICLE =
-        new EnumMap<ItalianModifierForm, String>(ImmutableMap.<ItalianModifierForm,String>builder()
+        new EnumMap<>(ImmutableMap.<ItalianModifierForm,String>builder()
                 .put(ItalianModifierForm.SINGULAR_FEMININE, "La ")
                 .put(ItalianModifierForm.SINGULAR_MASCULINE, "Il ")
                 .put(ItalianModifierForm.PLURAL_FEMININE, "Le ")
@@ -220,7 +224,7 @@ class ItalianDeclension extends RomanceDeclension {
                 .build());
 
     private static final EnumMap<ItalianModifierForm, String> INDEFINITE_ARTICLE =
-        new EnumMap<ItalianModifierForm, String>(ImmutableMap.<ItalianModifierForm,String>builder()
+        new EnumMap<>(ImmutableMap.<ItalianModifierForm,String>builder()
                 .put(ItalianModifierForm.SINGULAR_FEMININE, "Una ")
                 .put(ItalianModifierForm.SINGULAR_MASCULINE, "Un ")
                 .put(ItalianModifierForm.SINGULAR_FEMININE_V, "Un'")
@@ -238,11 +242,9 @@ class ItalianDeclension extends RomanceDeclension {
     protected Map< ? extends ArticleForm, String> getIndefiniteArticles() {
         return INDEFINITE_ARTICLE;
     }
-    
+
     @Override
     public Article createArticle(String name, LanguageArticle articleType) {
         return new ItalianArticle(this, name, articleType);
     }
-
-
 }

--- a/src/main/java/com/force/i18n/grammar/impl/KoreanDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/KoreanDeclension.java
@@ -81,10 +81,11 @@ public class KoreanDeclension extends AbstractLanguageDeclension implements With
      * Represents an english adjective
      */
     public static class KoreanAdjective extends Adjective {
+        private static final long serialVersionUID = -1L;
+
         private String prevEndsWithConsonant;
         private String prevEndsWithVowel;
         private String prevEndsWithSpecial;  // Ends with ㄹ
-        private static final long serialVersionUID = -1L;
 
         KoreanAdjective(KoreanDeclension declension, String name, LanguagePosition position) {
             super(declension, name, position);
@@ -131,6 +132,13 @@ public class KoreanDeclension extends AbstractLanguageDeclension implements With
             }
             return true;
         }
+
+        protected Object readResolve() {
+            this.prevEndsWithConsonant = intern(this.prevEndsWithConsonant);
+            this.prevEndsWithVowel = intern(this.prevEndsWithVowel);
+            this.prevEndsWithSpecial = intern(this.prevEndsWithSpecial);
+            return this;
+        }
     }
 
     /**
@@ -138,12 +146,11 @@ public class KoreanDeclension extends AbstractLanguageDeclension implements With
      * @author stamm
      */
     protected static class KoreanNoun extends Noun implements WithClassifier {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		String value;
-		String classifier;
+        private static final long serialVersionUID = 1L;
+
+        String value;
+        String classifier;
+
         protected KoreanNoun(KoreanDeclension declension, String name, String pluralAlias, NounType type, String entityName, LanguageStartsWith startsWith, String access, boolean isStandardField, boolean isCopiedFromDefault) {
             super(declension, name, pluralAlias, type, entityName, startsWith, LanguageGender.NEUTER, access, isStandardField, isCopiedFromDefault);
         }
@@ -165,7 +172,7 @@ public class KoreanDeclension extends AbstractLanguageDeclension implements With
 
         @Override
         public void setString(String value, NounForm form) {
-            this.value = value;
+            this.value = intern(value);
             // Calculate endwith
             LanguageStartsWith endsWith = LanguageStartsWith.CONSONANT;  // Assume consonant
             if (value != null) {
@@ -214,12 +221,20 @@ public class KoreanDeclension extends AbstractLanguageDeclension implements With
 
         @Override
         public void setClassifier(String classifier) {
-            this.classifier = classifier;
+            this.classifier = intern(classifier);
         }
 
         @Override
         public String getClassifier() {
             return this.classifier;
+        }
+
+        @Override
+        protected Object readResolve() {
+            super.readResolve();
+            this.value = intern(this.value);
+            this.classifier = intern(this.classifier);
+            return this;
         }
     }
 

--- a/src/main/java/com/force/i18n/grammar/impl/MalayoPolynesianDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/MalayoPolynesianDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -18,12 +18,12 @@ import com.force.i18n.grammar.Noun.NounType;
 import com.google.common.collect.ImmutableList;
 
 /**
- * Represents a Malayo-Polyesian language.  Generally non-inflected except for plurals, which 
+ * Represents a Malayo-Polyesian language.  Generally non-inflected except for plurals, which
  * are often formed by reduplication.  Sometimes in Maori it's through vowel
- * lengthening. 
- * 
+ * lengthening.
+ *
  * Maori and Somoan have definite and indefinite articles, but are uninflected.
- *   
+ *
  * @author stamm
  */
  class MalayoPolynesianDeclension extends AbstractLanguageDeclension {
@@ -82,19 +82,19 @@ import com.google.common.collect.ImmutableList;
     public Noun createNoun(String name, String pluralAlias, NounType type, String entityName, LanguageStartsWith startsWith, LanguageGender gender, String access, boolean isStandardField, boolean isCopied) {
         return new SimplePluralNoun(this, name, pluralAlias, type, entityName, access, isStandardField, isCopied);
     }
-    
+
     /**
      * Hawaiian is a MalayoPolynesian language, but has a definite article that
-     * changes based on the next word (ka/ke) vs "nā" plural.  Ke is used with 
+     * changes based on the next word (ka/ke) vs "nā" plural.  Ke is used with
      * works that start with k, e, a, or o, plus a few exceptional words like
      * table (kepākaukau), song (mele) and eating utensils.  See kūʻēlula.
-     * 
+     *
      * Ka is represented as starts with consonant.  Ke is represented as starts with special.
-     * 
+     *
      * Indefinite article is invariant (he).
-     * 
+     *
      * This is similar to English.
-     * 
+     *
      * @author stamm
      */
     static class HawaiianDeclension extends ArticledDeclension {
@@ -102,11 +102,11 @@ import com.google.common.collect.ImmutableList;
         public HawaiianDeclension(HumanLanguage language) {
     		super(language);
     	}
-        
+
         /**
          * The hawaiian articles are distinguished by whether the next noun starts with k,e,a,o,
          * and some changes for starts with ke vs ka.
-         * 
+         *
          */
         public static enum HawaiianArticleForm implements ArticleForm {
             KA(LanguageNumber.SINGULAR, LanguageStartsWith.CONSONANT),
@@ -147,10 +147,11 @@ import com.google.common.collect.ImmutableList;
          * Represents an english adjective
          */
         public static class HawaiianArticle extends Article {
+            private static final long serialVersionUID = 597093332610194996L; // javac generated value. Mandatory for javac/eclipse compatibility
+
             private String singular; // We only store one value
             private String singularVowel; // We only store one value
             private String plural; // We only store one value
-            private static final long serialVersionUID = 597093332610194996L; // javac generated value. Mandatory for javac/eclipse compatibility
 
             HawaiianArticle(HawaiianDeclension declension, String name, LanguageArticle articleType) {
                 super(declension, name, articleType);
@@ -166,10 +167,10 @@ import com.google.common.collect.ImmutableList;
             @Override
             public String getString(ArticleForm form) {
                 switch (HawaiianArticleForm.getForm(form)) {
-                case NA:  return plural;
+                case NA: return plural;
                 case KE: return singularVowel;
                 default:
-                case KA:  return singular;
+                case KA: return singular;
                 }
             }
 
@@ -195,6 +196,13 @@ import com.google.common.collect.ImmutableList;
                     this.plural = this.singular;
                 }
                 return true;
+            }
+
+            protected Object readResolve() {
+                this.singular = intern(this.singular);
+                this.singularVowel = intern(this.singularVowel);
+                this.plural = intern(this.plural);
+                return this;
             }
         }
 

--- a/src/main/java/com/force/i18n/grammar/impl/RomanceDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/RomanceDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -23,16 +23,16 @@ import com.google.common.collect.ImmutableMap;
  * @author yoikawa,stamm
  */
 abstract class RomanceDeclension extends ArticledDeclension {
-	private static EnumSet<LanguageGender> GENDER_TYPES = EnumSet.of(LanguageGender.FEMININE, LanguageGender.MASCULINE);
+    private static final EnumSet<LanguageGender> GENDER_TYPES = EnumSet.of(LanguageGender.FEMININE, LanguageGender.MASCULINE);
 
-    public RomanceDeclension(HumanLanguage language) {
-		super(language);
-	}
+    protected RomanceDeclension(HumanLanguage language) {
+        super(language);
+    }
 
     /**
      * Adjective form for languages that don't care about "starts with"
      */
-    public static enum RomanceModifierForm implements AdjectiveForm, ArticleForm {
+    public enum RomanceModifierForm implements AdjectiveForm, ArticleForm {
         SINGULAR_MASCULINE(LanguageNumber.SINGULAR, LanguageGender.MASCULINE),
         SINGULAR_FEMININE(LanguageNumber.SINGULAR, LanguageGender.FEMININE),
         PLURAL_MASCULINE(LanguageNumber.PLURAL, LanguageGender.MASCULINE),
@@ -52,29 +52,26 @@ abstract class RomanceDeclension extends ArticledDeclension {
         @Override public LanguageGender getGender() {return this.gender;}
         @Override public LanguageStartsWith getStartsWith() { return LanguageStartsWith.CONSONANT; }
         @Override public LanguagePossessive getPossessive() { return LanguagePossessive.NONE; }
-		@Override
-		public String getKey() {
-			return getNumber().getDbValue() + "-" + getGender().getDbValue();
-		}
 
-		@Override
-		public void appendJsFormReplacement(Appendable a, String termFormVar, String genderVar, String startsWithVar)
-				throws IOException {
-			a.append(termFormVar+".substr(0,2)+"+genderVar);
-		}
-		
+        @Override
+        public String getKey() {
+            return getNumber().getDbValue() + "-" + getGender().getDbValue();
+        }
+
+        @Override
+        public void appendJsFormReplacement(Appendable a, String termFormVar, String genderVar, String startsWithVar)
+                throws IOException {
+            a.append(termFormVar + ".substr(0,2)+" + genderVar);
+        }
     }
 
     /**
      * <CODE>Noun</CODE> implementation for the most Latin-1 language
      */
     protected static class RomanceNoun extends SimpleArticledPluralNoun {
-        /**
-		 * 
-		 */
-		private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
 
-		protected RomanceNoun(RomanceDeclension declension, String name, String pluralAlias, NounType type, String entityName, LanguageStartsWith startsWith, LanguageGender gender, String access, boolean isStandardField, boolean isCopiedFromDefault) {
+        protected RomanceNoun(RomanceDeclension declension, String name, String pluralAlias, NounType type, String entityName, LanguageStartsWith startsWith, LanguageGender gender, String access, boolean isStandardField, boolean isCopiedFromDefault) {
             super(declension, name, pluralAlias, type, entityName, startsWith, gender, access, isStandardField, isCopiedFromDefault);
         }
 
@@ -104,12 +101,10 @@ abstract class RomanceDeclension extends ArticledDeclension {
     }
 
     protected static class RomanceAdjective extends Adjective {
-        /**
-		 * 
-		 */
-		private static final long serialVersionUID = 1L;
-		// The "keys" here are StartsWith, Gender, and Plurality
-        EnumMap<RomanceModifierForm,String> values = new EnumMap<RomanceModifierForm,String>(RomanceModifierForm.class);
+        private static final long serialVersionUID = 1L;
+
+        // The "keys" here are StartsWith, Gender, and Plurality
+        EnumMap<RomanceModifierForm,String> values = new EnumMap<>(RomanceModifierForm.class);
 
         RomanceAdjective(LanguageDeclension declension, String name, LanguagePosition position) {
             super(declension, name, position);
@@ -131,20 +126,22 @@ abstract class RomanceDeclension extends ArticledDeclension {
             values.put((RomanceModifierForm)form, intern(value));
         }
 
-
         @Override
         public boolean validate(String name) {
             return defaultValidate(name, EnumSet.of(RomanceModifierForm.SINGULAR_FEMININE));
         }
+
+        protected Object readResolve() {
+            this.values.replaceAll((k, v) -> intern(v));
+            return this;
+        }
     }
 
     protected static class RomanceArticle extends Article {
-        /**
-		 * 
-		 */
-		private static final long serialVersionUID = 1L;
-		// The "keys" here are StartsWith, Gender, and Plurality
-        EnumMap<RomanceModifierForm,String> values = new EnumMap<RomanceModifierForm,String>(RomanceModifierForm.class);
+        private static final long serialVersionUID = 1L;
+
+        // The "keys" here are StartsWith, Gender, and Plurality
+        EnumMap<RomanceModifierForm,String> values = new EnumMap<>(RomanceModifierForm.class);
 
         RomanceArticle(RomanceDeclension declension, String name, LanguageArticle articleType) {
             super(declension, name, articleType);
@@ -169,6 +166,11 @@ abstract class RomanceDeclension extends ArticledDeclension {
         @Override
         public boolean validate(String name) {
             return defaultValidate(name, EnumSet.of(RomanceModifierForm.SINGULAR_FEMININE));
+        }
+
+        protected Object readResolve() {
+            this.values.replaceAll((k, v) -> intern(v));
+            return this;
         }
     }
 
@@ -303,27 +305,31 @@ abstract class RomanceDeclension extends ArticledDeclension {
     	}
 
         private static final EnumMap<RomanceModifierForm, String> INDEFINITE_ARTICLE =
-            new EnumMap<RomanceModifierForm, String>(ImmutableMap.of(
+            new EnumMap<>(ImmutableMap.of(
                     RomanceModifierForm.SINGULAR_FEMININE, "Una ",
                     RomanceModifierForm.SINGULAR_MASCULINE, "Un ",
                     RomanceModifierForm.PLURAL_FEMININE, "Unas ",
                     RomanceModifierForm.PLURAL_MASCULINE, "Unos "
                     ));
+
         private static final EnumMap<RomanceModifierForm, String> DEFINITE_ARTICLE =
-            new EnumMap<RomanceModifierForm, String>(ImmutableMap.of(
+            new EnumMap<>(ImmutableMap.of(
                     RomanceModifierForm.SINGULAR_FEMININE, "La ",
                     RomanceModifierForm.SINGULAR_MASCULINE, "El ",
                     RomanceModifierForm.PLURAL_FEMININE, "Las ",
                     RomanceModifierForm.PLURAL_MASCULINE, "Los "
                     ));
+
         @Override
         protected Map<RomanceModifierForm, String> getDefiniteArticles() {
             return DEFINITE_ARTICLE;
         }
+
         @Override
         protected Map<RomanceModifierForm, String> getIndefiniteArticles() {
             return INDEFINITE_ARTICLE;
         }
+
         @Override
         public Article createArticle(String name, LanguageArticle articleType) {
             return new RomanceArticle(this, name, articleType);
@@ -338,31 +344,34 @@ abstract class RomanceDeclension extends ArticledDeclension {
         }
 
         private static final EnumMap<RomanceModifierForm, String> INDEFINITE_ARTICLE =
-            new EnumMap<RomanceModifierForm, String>(ImmutableMap.of(
+            new EnumMap<>(ImmutableMap.of(
                     RomanceModifierForm.SINGULAR_FEMININE, "Uma ",
                     RomanceModifierForm.SINGULAR_MASCULINE, "Um ",
                     RomanceModifierForm.PLURAL_FEMININE, "Umas ",
                     RomanceModifierForm.PLURAL_MASCULINE, "Uns "
                     ));
+
         private static final EnumMap<RomanceModifierForm, String> DEFINITE_ARTICLE =
-            new EnumMap<RomanceModifierForm, String>(ImmutableMap.of(
+            new EnumMap<>(ImmutableMap.of(
                     RomanceModifierForm.SINGULAR_FEMININE, "A ",
                     RomanceModifierForm.SINGULAR_MASCULINE, "O ",
                     RomanceModifierForm.PLURAL_FEMININE, "As ",
                     RomanceModifierForm.PLURAL_MASCULINE, "Os "
                     ));
+
         @Override
         protected Map<RomanceModifierForm, String> getDefiniteArticles() {
             return DEFINITE_ARTICLE;
         }
+
         @Override
         protected Map<RomanceModifierForm, String> getIndefiniteArticles() {
             return INDEFINITE_ARTICLE;
         }
+
         @Override
         public Article createArticle(String name, LanguageArticle articleType) {
             return new RomanceArticle(this, name, articleType);
         }
-
     }
 }

--- a/src/main/java/com/force/i18n/grammar/impl/RomanianDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/RomanianDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -71,11 +71,9 @@ class RomanianDeclension extends RomanceDeclension {
 
 
     public static class RomanianNounForm extends ComplexNounForm {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private final LanguageNumber number;
+        private static final long serialVersionUID = 1L;
+
+        private final LanguageNumber number;
         private final LanguageCase caseType;
         private final LanguageArticle article;
 
@@ -95,9 +93,25 @@ class RomanianDeclension extends RomanceDeclension {
         public String getKey() {
             return getNumber().getDbValue() + "-" + getCase().getDbValue() + getArticle().getDbValue();
         }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), this.number, this.caseType, this.article);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (other instanceof RomanianNounForm) {
+                RomanianNounForm o = this.getClass().cast(other);
+                return super.equals(other) && this.number == o.number && this.caseType == o.caseType
+                        && this.article == o.article;
+            }
+            return false;
+        }
     }
 
-    public static enum RomanianModifierForm implements ArticleForm, AdjectiveForm {
+    public enum RomanianModifierForm implements ArticleForm, AdjectiveForm {
         // Yeah, I could have generated this, but making it an enum wasn't that big a difference
         SINGULAR_N(LanguageNumber.SINGULAR, LanguageCase.NOMINATIVE, LanguageGender.NEUTER),
         SINGULAR_M(LanguageNumber.SINGULAR, LanguageCase.NOMINATIVE, LanguageGender.MASCULINE),
@@ -128,32 +142,35 @@ class RomanianDeclension extends RomanceDeclension {
         @Override public LanguageStartsWith getStartsWith() { return LanguageStartsWith.CONSONANT; }
         @Override public LanguageArticle getArticle() { return LanguageArticle.ZERO; }
         @Override public LanguagePossessive getPossessive() { return LanguagePossessive.NONE; }
-		@Override
-		public String getKey() {
-			return getGender().getDbValue() + "-" + getCase().getDbValue() + "-" + getNumber().getDbValue();
-		}
-		@Override
-		public void appendJsFormReplacement(Appendable a, String termFormVar, String genderVar, String startsWithVar)
-				throws IOException {
-			a.append(genderVar+"+"+termFormVar+".substr(1)");
-		}
+
+        @Override
+        public String getKey() {
+            return getGender().getDbValue() + "-" + getCase().getDbValue() + "-" + getNumber().getDbValue();
+        }
+
+        @Override
+        public void appendJsFormReplacement(Appendable a, String termFormVar, String genderVar, String startsWithVar)
+                throws IOException {
+            a.append(genderVar + "+" + termFormVar + ".substr(1)");
+        }
     }
 
     /**
      * <CODE>Noun</CODE> implementation for the most Latin-1 language
      */
     protected static class RomanianNoun extends ComplexArticledNoun<RomanianNounForm> {
-		private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
+
         protected RomanianNoun(RomanianDeclension declension, String name, String pluralAlias, NounType type, String entityName, LanguageGender gender, String access, boolean isStandardField, boolean isCopiedFromDefault) {
             super(declension, name, pluralAlias, type, entityName, LanguageStartsWith.CONSONANT, gender, access, isStandardField, isCopiedFromDefault);
         }
 
         @Override
-		protected final Class<RomanianNounForm> getFormClass() {
-        	return RomanianNounForm.class;
-		}
+        protected final Class<RomanianNounForm> getFormClass() {
+            return RomanianNounForm.class;
+        }
 
-		@Override
+        @Override
         protected boolean validateValues(String name, LanguageCase _case) {
             for (NounForm form : getDeclension().getAllNounForms()) {
                 if (getString(form) == null) {
@@ -174,12 +191,10 @@ class RomanianDeclension extends RomanceDeclension {
     }
 
     protected static class RomanianAdjective extends Adjective {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		// The "keys" here are StartsWith, Gender, and Plurality
-        EnumMap<RomanianModifierForm,String> values = new EnumMap<RomanianModifierForm,String>(RomanianModifierForm.class);
+        private static final long serialVersionUID = 1L;
+
+        // The "keys" here are StartsWith, Gender, and Plurality
+        EnumMap<RomanianModifierForm, String> values = new EnumMap<>(RomanianModifierForm.class);
 
         RomanianAdjective(LanguageDeclension declension, String name, LanguagePosition position) {
             super(declension, name, position);
@@ -201,20 +216,22 @@ class RomanianDeclension extends RomanceDeclension {
             values.put((RomanianModifierForm)form, intern(value));
         }
 
-
         @Override
         public boolean validate(String name) {
             return defaultValidate(name, EnumSet.allOf(RomanianModifierForm.class));
         }
+
+        protected Object readResolve() {
+            this.values.replaceAll((k, v) -> intern(v));
+            return this;
+        }
     }
 
     protected static class RomanianArticle extends Article {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		// The "keys" here are StartsWith, Gender, and Plurality
-        EnumMap<RomanianModifierForm,String> values = new EnumMap<RomanianModifierForm,String>(RomanianModifierForm.class);
+        private static final long serialVersionUID = 1L;
+
+        // The "keys" here are StartsWith, Gender, and Plurality
+        EnumMap<RomanianModifierForm, String> values = new EnumMap<>(RomanianModifierForm.class);
 
         RomanianArticle(RomanianDeclension declension, String name, LanguageArticle articleType) {
             super(declension, name, articleType);
@@ -243,6 +260,11 @@ class RomanianDeclension extends RomanceDeclension {
                     RomanianModifierForm.PLURAL_N, RomanianModifierForm.SINGULAR_DAT_F,
                     RomanianModifierForm.SINGULAR_DAT_M, RomanianModifierForm.SINGULAR_DAT_N,
                     RomanianModifierForm.PLURAL_DAT_N ));
+        }
+
+        protected Object readResolve() {
+            this.values.replaceAll((k, v) -> intern(v));
+            return this;
         }
     }
 
@@ -289,7 +311,6 @@ class RomanianDeclension extends RomanceDeclension {
         return ALL_MODIFIER_FORMS;
     }
 
-
     @Override
     public EnumSet<LanguageCase> getRequiredCases() {
         return EnumSet.of(LanguageCase.NOMINATIVE, LanguageCase.DATIVE);
@@ -300,7 +321,7 @@ class RomanianDeclension extends RomanceDeclension {
         return Collections.singleton(fieldForms.get(0));  // Only need "singular" for other forms
     }
 
-    private static final Map<RomanianModifierForm,String> INDEFINITE_ARTICLES =
+    private static final Map<RomanianModifierForm, String> INDEFINITE_ARTICLES =
         ImmutableMap.<RomanianModifierForm, String>builder()
             .put(RomanianModifierForm.SINGULAR_N, "un ")
             .put(RomanianModifierForm.SINGULAR_F, "o ")
@@ -341,8 +362,6 @@ class RomanianDeclension extends RomanceDeclension {
 
     }
 
-
-
     @Override
     public ArticleForm getArticleForm(LanguageStartsWith startsWith, LanguageGender gender, LanguageNumber number,
             LanguageCase _case) {
@@ -381,7 +400,6 @@ class RomanianDeclension extends RomanceDeclension {
             return getIndefiniteArticles().get(form);
         default:
             return null;
-
         }
     }
 }

--- a/src/main/java/com/force/i18n/grammar/impl/SimpleDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/SimpleDeclension.java
@@ -69,6 +69,7 @@ class SimpleDeclension extends AbstractLanguageDeclension {
      */
     public static class SimpleNoun extends Noun {
         private static final long serialVersionUID = 1L;
+
         protected String value;
 
         SimpleNoun(LanguageDeclension declension, String name, String pluralAlias, NounType type, String entityName, String access, boolean isStandardField, boolean isCopiedFromDefault) {
@@ -115,6 +116,13 @@ class SimpleDeclension extends AbstractLanguageDeclension {
             }
 ///CLOVER:ON
             return true;
+        }
+
+        @Override
+        protected Object readResolve() {
+            super.readResolve();
+            this.value = intern(this.value);
+            return this;
         }
     }
 
@@ -290,7 +298,7 @@ class SimpleDeclension extends AbstractLanguageDeclension {
         }
 
     }
-    
+
     /**
      * Hmong declension that is similar to SimpleDeclention, but has capitalization and classifiers.
      *
@@ -365,12 +373,20 @@ class SimpleDeclension extends AbstractLanguageDeclension {
 
         @Override
         public void setClassifier(String classifier) {
-            this.classifier = classifier;
+            this.classifier = intern(classifier);
+        }
+
+        @Override
+        protected Object readResolve() {
+            super.readResolve();
+            this.classifier = intern(this.classifier);
+            return this;
         }
     }
 
     static class PluralNounWithClassifier extends SimpleNounWithClassifier {
         private static final long serialVersionUID = 1L;
+
         private String plural;
 
         public PluralNounWithClassifier(LanguageDeclension declension, String name, String pluralAlias, NounType type,
@@ -418,6 +434,13 @@ class SimpleDeclension extends AbstractLanguageDeclension {
                 return false;
             }
             return true;
+        }
+
+        @Override
+        protected Object readResolve() {
+            super.readResolve();
+            this.plural = intern(this.plural);
+            return this;
         }
     }
 }

--- a/src/main/java/com/force/i18n/grammar/impl/SimpleDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/SimpleDeclension.java
@@ -97,13 +97,11 @@ class SimpleDeclension extends AbstractLanguageDeclension {
 
         @Override
         public String getString(NounForm form) {
-            assert form instanceof SimpleNounForm : "Why are you asking for some random noun form.  Really?";
             return value;
         }
 
         @Override
         protected void setString(String value, NounForm form) {
-            assert form instanceof SimpleNounForm : "Why are you asking for some random noun form.  Really?";
             this.value = intern(value);
         }
 

--- a/src/main/java/com/force/i18n/grammar/impl/SlavicDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/SlavicDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -34,7 +34,7 @@ abstract class SlavicDeclension extends AbstractLanguageDeclension {
     private final List<SlavicAdjectiveForm> adjectiveForms;
     private final ModifierFormMap<SlavicAdjectiveForm> adjectiveFormMap;
 
-    public SlavicDeclension(HumanLanguage language) {
+    protected SlavicDeclension(HumanLanguage language) {
     	super(language);
         // Generate the different forms from subclass methods
         ImmutableList.Builder<SlavicNounForm> nounBuilder = ImmutableList.builder();
@@ -61,7 +61,7 @@ abstract class SlavicDeclension extends AbstractLanguageDeclension {
                 }
             }
         }
-        
+
         if (getMasculineAnimateForms() != null) {
             //add animate masculine forms, if any
             for (Map.Entry<LanguageNumber, EnumSet<LanguageCase>> entry : getMasculineAnimateForms().entrySet()) {
@@ -70,18 +70,15 @@ abstract class SlavicDeclension extends AbstractLanguageDeclension {
                 }
             }
         }
-        
+
         this.adjectiveForms = adjBuilder.build();
         this.adjectiveFormMap = new ModifierFormMap<SlavicAdjectiveForm>(this.adjectiveForms);
     }
 
-
     static class SlavicNounForm extends ComplexNounForm {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private final LanguageCase caseType;
+        private static final long serialVersionUID = 1L;
+
+        private final LanguageCase caseType;
         private final LanguageNumber number;
 
         public SlavicNounForm(LanguageDeclension declension, LanguageNumber number, LanguageCase caseType, int ordinal) {
@@ -94,22 +91,37 @@ abstract class SlavicDeclension extends AbstractLanguageDeclension {
         @Override public LanguageCase getCase() {  return this.caseType; }
         @Override public LanguageNumber getNumber() {  return this.number; }
         @Override public LanguagePossessive getPossessive() { return LanguagePossessive.NONE;}
+
         @Override
         public String getKey() {
             return getNumber().getDbValue() + "-" + getCase().getDbValue();
         }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), this.caseType, this.number);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (other instanceof SlavicNounForm) {
+                SlavicNounForm o = this.getClass().cast(other);
+                return super.equals(other) && this.caseType == o.caseType && this.number == o.number;
+            }
+            return false;
+        }
+
         @Override
         public String toString() {
-            return "SlavicNF:"+getKey();
+            return "SlavicNF:" + getKey();
         }
     }
 
     static class SlavicAdjectiveForm extends ComplexAdjectiveForm {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private final LanguageNumber number;
+        private static final long serialVersionUID = 1L;
+
+        private final LanguageNumber number;
         private final LanguageCase caseType;
         private final LanguageGender gender;
 
@@ -126,12 +138,27 @@ abstract class SlavicDeclension extends AbstractLanguageDeclension {
         @Override public LanguageStartsWith getStartsWith() {  return LanguageStartsWith.CONSONANT; }
         @Override public LanguageGender getGender() {  return this.gender; }
         @Override public LanguagePossessive getPossessive() { return LanguagePossessive.NONE; }
-		@Override
-		public String getKey() {
-			return getGender().getDbValue() + "-" + getNumber().getDbValue() + "-" + getCase().getDbValue();
-		}
-		
 
+        @Override
+        public String getKey() {
+            return getGender().getDbValue() + "-" + getNumber().getDbValue() + "-" + getCase().getDbValue();
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), this.caseType, this.number, this.gender);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (other instanceof SlavicAdjectiveForm) {
+                SlavicAdjectiveForm o = this.getClass().cast(other);
+                return super.equals(other) && this.caseType == o.caseType && this.number == o.number
+                        && this.gender == o.gender;
+            }
+            return false;
+        }
     }
 
     /**
@@ -139,15 +166,18 @@ abstract class SlavicDeclension extends AbstractLanguageDeclension {
      * See SlavicNounForm for more info
      */
     public static class SlavicNoun extends ComplexNoun<SlavicNounForm> {
-		private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
+
         SlavicNoun(LanguageDeclension declension, String name, String pluralAlias, NounType type, String entityName, LanguageGender gender, String access, boolean isStandardField, boolean isCopiedFromDefault) {
             super(declension, name, pluralAlias, type, entityName, LanguageStartsWith.CONSONANT, gender, access, isStandardField, isCopiedFromDefault);
         }
+
         @Override
-		protected Class<SlavicNounForm> getFormClass() {
-        	return SlavicNounForm.class;
-		}
-		@Override
+        protected Class<SlavicNounForm> getFormClass() {
+            return SlavicNounForm.class;
+        }
+
+        @Override
         protected boolean validateValues(String name, LanguageCase _case) {
             return defaultValidate(name, getDeclension().getFieldForms());
         }
@@ -166,18 +196,17 @@ abstract class SlavicDeclension extends AbstractLanguageDeclension {
      * Represents an english adjective
      */
     public static class SlavicAdjective extends ComplexAdjective<SlavicAdjectiveForm> {
-		private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
+
         SlavicAdjective(LanguageDeclension declension, String name, LanguagePosition position) {
             super(declension, name, position);
         }
 
-		@Override
-		protected Class<SlavicAdjectiveForm> getFormClass() {
-			return SlavicAdjectiveForm.class;
-		}
-
+        @Override
+        protected Class<SlavicAdjectiveForm> getFormClass() {
+            return SlavicAdjectiveForm.class;
+        }
    }
-
 
     @Override
     public Adjective createAdjective(String name, LanguageStartsWith startsWith, LanguagePosition position) {
@@ -189,7 +218,6 @@ abstract class SlavicDeclension extends AbstractLanguageDeclension {
             LanguageGender gender, String access, boolean isStandardField, boolean isCopied) {
         return new SlavicNoun(this, name, pluralAlias, type, entityName, gender, access, isStandardField, isCopied);
     }
-
 
     @Override
     public List< ? extends AdjectiveForm> getAdjectiveForms() {
@@ -230,7 +258,6 @@ abstract class SlavicDeclension extends AbstractLanguageDeclension {
         return this.nounFormMap.getForm(number, _case);
     }
 
-
     @Override
     public boolean hasArticle() {
         return false;
@@ -250,7 +277,7 @@ abstract class SlavicDeclension extends AbstractLanguageDeclension {
     public boolean hasStartsWith() {
         return false;
     }
-    
+
     /**
      * A few slavic adjective forms use the gender masculine animate.
      * @return map of number to list of cases that use that gender
@@ -265,21 +292,21 @@ abstract class SlavicDeclension extends AbstractLanguageDeclension {
 
     static class CzechDeclension extends SlavicDeclension {
         public CzechDeclension(HumanLanguage language) {
-			super(language);
-		}
+            super(language);
+        }
 
-		@Override
+        @Override
         public EnumSet<LanguageCase> getRequiredCases() {
             return WEST_SLAVIC_CASES;
         }
-        
+
         @Override
         public Map<LanguageNumber, EnumSet<LanguageCase>> getMasculineAnimateForms() {
            return ImmutableMap.of(
                    LanguageNumber.PLURAL, EnumSet.of(NOMINATIVE, VOCATIVE),
                    LanguageNumber.SINGULAR, EnumSet.of(ACCUSATIVE));
         }
-        
+
         @Override
         public EnumSet<LanguageGender> getRequiredGenders() {
             return WEST_SLAVIC_GENDERS;
@@ -288,34 +315,33 @@ abstract class SlavicDeclension extends AbstractLanguageDeclension {
 
     static class PolishDeclension extends SlavicDeclension {
         public PolishDeclension(HumanLanguage language) {
-			super(language);
-		}
+            super(language);
+        }
 
         @Override
         public EnumSet<LanguageCase> getRequiredCases() {
             return WEST_SLAVIC_CASES;
         }
-        
+
         @Override
         public Map<LanguageNumber, EnumSet<LanguageCase>> getMasculineAnimateForms() {
            return ImmutableMap.of(
                    LanguageNumber.PLURAL, EnumSet.of(NOMINATIVE, ACCUSATIVE),
                    LanguageNumber.SINGULAR, EnumSet.of(ACCUSATIVE));
         }
-        
+
         @Override
         public EnumSet<LanguageGender> getRequiredGenders() {
             return WEST_SLAVIC_GENDERS;
         }
     }
 
-
     static class RussianDeclension extends SlavicDeclension {
         public RussianDeclension(HumanLanguage language) {
-			super(language);
-		}
+            super(language);
+        }
 
-		@Override
+        @Override
         public EnumSet<LanguageCase> getRequiredCases() {
             return EnumSet.of(NOMINATIVE, ACCUSATIVE, DATIVE, GENITIVE, INSTRUMENTAL, PREPOSITIONAL);
         }
@@ -324,13 +350,13 @@ abstract class SlavicDeclension extends AbstractLanguageDeclension {
         public boolean shouldLowercaseEntityInCompoundNouns() {
             return true;
         }
-        
+
         @Override
         public Map<LanguageNumber, EnumSet<LanguageCase>> getMasculineAnimateForms() {
            return ImmutableMap.of(LanguageNumber.PLURAL, EnumSet.of(ACCUSATIVE),
                                   LanguageNumber.SINGULAR, EnumSet.of(ACCUSATIVE));
-        }  
-        
+        }
+
         @Override
         public EnumSet<LanguageGender> getRequiredGenders() {
             return WEST_SLAVIC_GENDERS;
@@ -339,21 +365,21 @@ abstract class SlavicDeclension extends AbstractLanguageDeclension {
 
     static class UkrainianDeclension extends SlavicDeclension {
         public UkrainianDeclension(HumanLanguage language) {
-			super(language);
-		}
+            super(language);
+        }
 
-		@Override
+        @Override
         public EnumSet<LanguageCase> getRequiredCases() {
             return WEST_SLAVIC_CASES;
         }
-        
+
         @Override
         public Map<LanguageNumber, EnumSet<LanguageCase>> getMasculineAnimateForms() {
            return ImmutableMap.of(
                    LanguageNumber.PLURAL, EnumSet.of(ACCUSATIVE),
                    LanguageNumber.SINGULAR, EnumSet.of(ACCUSATIVE));
-        }   
-        
+        }
+
         @Override
         public EnumSet<LanguageGender> getRequiredGenders() {
             return WEST_SLAVIC_GENDERS;
@@ -363,47 +389,47 @@ abstract class SlavicDeclension extends AbstractLanguageDeclension {
 
     static class SlovakianDeclension extends SlavicDeclension {
         public SlovakianDeclension(HumanLanguage language) {
-			super(language);
-		}
+            super(language);
+        }
 
-		@Override
+        @Override
         public EnumSet<LanguageCase> getRequiredCases() {
             return WEST_SLAVIC_CASES_NO_VOC;
         }
-        
+
         @Override
         public Map<LanguageNumber, EnumSet<LanguageCase>> getMasculineAnimateForms() {
            return ImmutableMap.of(
                    LanguageNumber.PLURAL, EnumSet.of(NOMINATIVE, ACCUSATIVE),
                    LanguageNumber.SINGULAR, EnumSet.of(ACCUSATIVE));
-        }       
-        
+        }
+
         @Override
         public EnumSet<LanguageGender> getRequiredGenders() {
             return WEST_SLAVIC_GENDERS;
-        } 
+        }
     }
 
     static class SlovenianDeclension extends SlavicDeclension {
         public SlovenianDeclension(HumanLanguage language) {
-			super(language);
-		}
- 
+            super(language);
+        }
+
         @Override
         public EnumSet<LanguageCase> getRequiredCases() {
             return WEST_SLAVIC_CASES;
         }
-        
+
         @Override
         public Map<LanguageNumber, EnumSet<LanguageCase>> getMasculineAnimateForms() {
            return ImmutableMap.of(LanguageNumber.SINGULAR, EnumSet.of(ACCUSATIVE));
         }
-        
+
         @Override
         public EnumSet<LanguageGender> getRequiredGenders() {
             return WEST_SLAVIC_GENDERS;
         }
-        
+
         @Override
         public Set<LanguageNumber> getAllowedNumbers() {
             return LanguageNumber.DUAL_SET;  // Duals are really required.
@@ -434,10 +460,10 @@ abstract class SlavicDeclension extends AbstractLanguageDeclension {
      */
     static class GeorgianDeclension extends SlavicDeclension {
         public GeorgianDeclension(HumanLanguage language) {
-			super(language);
-		}
+            super(language);
+        }
 
-		@Override
+        @Override
         public EnumSet<LanguageCase> getRequiredCases() {
             return EnumSet.of(LanguageCase.NOMINATIVE, LanguageCase.ERGATIVE, LanguageCase.DATIVE,
                     LanguageCase.GENITIVE, LanguageCase.INSTRUMENTAL, LanguageCase.ADVERBIAL);

--- a/src/main/java/com/force/i18n/grammar/impl/TurkicDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/TurkicDeclension.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -20,7 +20,7 @@ import com.force.i18n.grammar.impl.ComplexGrammaticalForm.ComplexNounForm;
 import com.google.common.collect.ImmutableList;
 
 /**
- * Turk Turk Turkish! 
+ * Turk Turk Turkish!
  *
  * Nouns are very complex
  * Adjectives and articles are dead simple.
@@ -83,35 +83,50 @@ abstract class TurkicDeclension extends ArticledDeclension {
      * Turkish nouns are inflected for case, number, and possessive
      */
     static class TurkishNounForm extends ComplexNounForm {
-        /**
-		 *
-		 */
-		private static final long serialVersionUID = 1L;
-		private final LanguageCase caseType;
-        private final LanguageNumber number;
-        private final LanguagePossessive possesive;
+        private static final long serialVersionUID = 1L;
 
-        public TurkishNounForm(LanguageDeclension declension, LanguageNumber number, LanguageCase caseType, LanguagePossessive possesive, int ordinal) {
+        private final LanguageCase caseType;
+        private final LanguageNumber number;
+        private final LanguagePossessive possessive;
+
+        public TurkishNounForm(LanguageDeclension declension, LanguageNumber number, LanguageCase caseType, LanguagePossessive possessive, int ordinal) {
             super(declension, ordinal);
             this.number = number;
             this.caseType = caseType;
-            this.possesive = possesive;
+            this.possessive = possessive;
         }
 
         @Override public LanguageArticle getArticle() { return LanguageArticle.ZERO; }
         @Override public LanguageCase getCase() {  return this.caseType; }
         @Override public LanguageNumber getNumber() {  return this.number; }
-        @Override public LanguagePossessive getPossessive() { return possesive;}
+        @Override public LanguagePossessive getPossessive() { return possessive; }
+
         @Override
         public String getKey() {
             return getNumber().getDbValue() + "-" + getCase().getDbValue() + "-" + getPossessive().getDbValue();
         }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), this.caseType, this.number, this.possessive);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (other instanceof TurkishNounForm) {
+                TurkishNounForm o = this.getClass().cast(other);
+                return super.equals(other) && this.caseType == o.caseType && this.number == o.number
+                        && this.possessive == o.possessive;
+            }
+            return false;
+        }
+
         @Override
         public String toString() {
             return "TurkishNF:" + getKey();
         }
     }
-
 
     /**
      * Represents an Turkish noun.
@@ -119,10 +134,11 @@ abstract class TurkicDeclension extends ArticledDeclension {
      */
     public static class TurkishNoun extends ComplexArticledNoun<TurkishNounForm> {
 		private static final long serialVersionUID = 1L;
+
         TurkishNoun(TurkicDeclension declension, String name, String pluralAlias, NounType type, String entityName, LanguageStartsWith startsWith, String access, boolean isStandardField, boolean isCopiedFromDefault) {
             super(declension, name, pluralAlias, type, entityName, startsWith, LanguageGender.NEUTER, access, isStandardField, isCopiedFromDefault);
         }
-        
+
         @Override
 		protected final Class<TurkishNounForm> getFormClass() {
         	return TurkishNounForm.class;
@@ -189,8 +205,6 @@ abstract class TurkicDeclension extends ArticledDeclension {
         return SimpleDeclension.ADJECTIVE_FORMS;
     }
 
-
-
     @Override
     public List< ? extends NounForm> getAllNounForms() {
         return this.entityForms;
@@ -210,40 +224,40 @@ abstract class TurkicDeclension extends ArticledDeclension {
     public Collection< ? extends NounForm> getOtherForms() {
         return Collections.singleton(fieldForms.get(0));  // Only need "singular" for other forms
     }
-    
+
     /**
      * Turkish is the default.
      * @author stamm
      */
     static class TurkishDeclension extends TurkicDeclension {
-		public TurkishDeclension(HumanLanguage language) {
-			super(language);
-		}
+        public TurkishDeclension(HumanLanguage language) {
+            super(language);
+        }
     }
-    
+
     /**
      * Kazakh has an instrumental case, and doesn't have articles.
-     * However, it does use "one" or "bir" to represent indefiniteness, like turkish does.  Sorta.  
-     * 
+     * However, it does use "one" or "bir" to represent indefiniteness, like turkish does.  Sorta.
+     *
      * @author stamm
      */
     static class KazakhDeclension extends TurkicDeclension {
-		public KazakhDeclension(HumanLanguage language) {
-			super(language);
-		}
-		
-	    @Override
-	    public EnumSet<LanguageCase> getRequiredCases() {
-	        return EnumSet.of(NOMINATIVE, ACCUSATIVE, DATIVE, LOCATIVE, GENITIVE, ABLATIVE, INSTRUMENTAL);
-	    }
-		
-	    @Override
-	    public String getDefaultArticleString(ArticleForm form, LanguageArticle articleType) {
-	        if (articleType == LanguageArticle.INDEFINITE) {
-	            return "Бір ";  //
-	        } else {
-	            return null;
-	        }
-	    }
+        public KazakhDeclension(HumanLanguage language) {
+            super(language);
+        }
+
+        @Override
+        public EnumSet<LanguageCase> getRequiredCases() {
+            return EnumSet.of(NOMINATIVE, ACCUSATIVE, DATIVE, LOCATIVE, GENITIVE, ABLATIVE, INSTRUMENTAL);
+        }
+
+        @Override
+        public String getDefaultArticleString(ArticleForm form, LanguageArticle articleType) {
+            if (articleType == LanguageArticle.INDEFINITE) {
+                return "Бір "; //
+            } else {
+                return null;
+            }
+        }
     }
 }

--- a/src/main/java/com/force/i18n/grammar/impl/UnsupportedLanguageDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/UnsupportedLanguageDeclension.java
@@ -149,8 +149,8 @@ abstract class UnsupportedLanguageDeclension extends ArticledDeclension {
      */
     static class IrishDeclension extends CelticDeclension {
         public IrishDeclension(HumanLanguage language) {
-			super(language);
-		}
+            super(language);
+        }
 
         static final List<? extends NounForm> GA_ALL_FORMS = ImmutableList.copyOf(EnumSet.allOf(IrishNounForm.class));
         public static enum IrishNounForm implements NounForm {
@@ -178,11 +178,9 @@ abstract class UnsupportedLanguageDeclension extends ArticledDeclension {
         }
 
         public static final class IrishNoun extends LegacyArticledNoun {
-            /**
-			 *
-			 */
-			private static final long serialVersionUID = 1L;
-			private String singular;
+            private static final long serialVersionUID = 1L;
+
+            private String singular;
             private String plural;
             private String singular_gen;
             private String plural_gen;
@@ -200,16 +198,19 @@ abstract class UnsupportedLanguageDeclension extends ArticledDeclension {
                 return enumMapFilterNulls(IrishNounForm.SINGULAR, singular, IrishNounForm.PLURAL, plural, IrishNounForm.SINGULAR_GEN, singular_gen,
                         IrishNounForm.PLURAL_GEN, plural_gen);
             }
+
             @Override
             public String getDefaultString(boolean isPlural) {
                 return isPlural ? (plural != null ? plural : singular) : singular;
             }
+
             @Override
             public String getExactString(NounForm form) {
                 assert form instanceof IrishNounForm : "Trying to trick a leprechaun out of his gold with a non-irish noun form? " + form;
                 return form.getCase() == LanguageCase.GENITIVE ? form.getNumber() == LanguageNumber.PLURAL ? plural_gen : singular_gen
                         : form.getNumber() == LanguageNumber.PLURAL ? plural : singular;
             }
+
             @Override
             public void setString(String value, NounForm form) {
                 if (form.getCase() == LanguageCase.GENITIVE) {
@@ -226,6 +227,7 @@ abstract class UnsupportedLanguageDeclension extends ArticledDeclension {
                     }
                 }
             }
+
             @Override
             protected boolean validateValues(String name, LanguageCase _case) {
                 if (this.singular == null) {
@@ -246,6 +248,16 @@ abstract class UnsupportedLanguageDeclension extends ArticledDeclension {
                     }
                 }
                 return true;
+            }
+
+            @Override
+            protected Object readResolve() {
+                super.readResolve();
+                this.singular = intern(this.singular);
+                this.plural = intern(this.plural);
+                this.singular_gen = intern(this.singular_gen);
+                this.plural_gen = intern(this.plural_gen);
+                return this;
             }
         }
 
@@ -286,10 +298,10 @@ abstract class UnsupportedLanguageDeclension extends ArticledDeclension {
      */
     static class MalteseDeclension extends UnsupportedLanguageDeclension {
         public MalteseDeclension(HumanLanguage language) {
-			super(language);
-		}
+            super(language);
+        }
 
-		@Override
+        @Override
         public LanguagePosition getDefaultAdjectivePosition() {
             return LanguagePosition.POST;
         }
@@ -303,10 +315,10 @@ abstract class UnsupportedLanguageDeclension extends ArticledDeclension {
      */
     abstract static class UnsupportedAsSimpleDeclension extends UnsupportedLanguageDeclension {
         public UnsupportedAsSimpleDeclension(HumanLanguage language) {
-			super(language);
-		}
+            super(language);
+        }
 
-		// Unsupported language where plurals are formed using complicated aggutinations.
+        // Unsupported language where plurals are formed using complicated aggutinations.
         @Override
         public List< ? extends NounForm> getAllNounForms() {
             return Collections.singletonList(SimpleNounForm.SINGULAR);
@@ -316,7 +328,6 @@ abstract class UnsupportedLanguageDeclension extends ArticledDeclension {
         public boolean hasPlural() {
             return false;
         }
-
 
         @Override
         public Noun createNoun(String name, String pluralAlias, NounType type, String entityName, LanguageStartsWith startsWith, LanguageGender gender, String access, boolean isStandardField, boolean isCopied) {
@@ -348,8 +359,8 @@ abstract class UnsupportedLanguageDeclension extends ArticledDeclension {
      */
     static class HaitianCreoleDeclension extends UnsupportedAsSimpleDeclension {
         public HaitianCreoleDeclension(HumanLanguage language) {
-			super(language);
-		}
+            super(language);
+        }
     }
 
 
@@ -360,8 +371,8 @@ abstract class UnsupportedLanguageDeclension extends ArticledDeclension {
      */
     static class BasqueDeclension extends UnsupportedAsSimpleDeclension {
         public BasqueDeclension(HumanLanguage language) {
-			super(language);
-		}
+            super(language);
+        }
     }
 
     /**
@@ -375,8 +386,8 @@ abstract class UnsupportedLanguageDeclension extends ArticledDeclension {
      */
     static class GreenlandicDeclension extends UnsupportedAsSimpleDeclension {
         public GreenlandicDeclension(HumanLanguage language) {
-			super(language);
-		}
+            super(language);
+        }
     }
 
     /**
@@ -388,8 +399,8 @@ abstract class UnsupportedLanguageDeclension extends ArticledDeclension {
      */
     static class PersianDeclension extends AbstractLanguageDeclension {
         public PersianDeclension(HumanLanguage language) {
-			super(language);
-		}
+            super(language);
+        }
 
         static final List<? extends NounForm> FA_ALL_FORMS = ImmutableList.copyOf(EnumSet.allOf(PersianNounForm.class));
         static final List<? extends NounForm> FA_SING_FORMS = ImmutableList.of(PersianNounForm.SINGULAR);
@@ -418,11 +429,9 @@ abstract class UnsupportedLanguageDeclension extends ArticledDeclension {
         }
 
         public static final class PersianNoun extends Noun {
-            /**
-			 *
-			 */
-			private static final long serialVersionUID = 1L;
-			private String singular;
+            private static final long serialVersionUID = 1L;
+
+            private String singular;
             private String plural;
             private String singular_acc;
             private String plural_acc;
@@ -445,14 +454,13 @@ abstract class UnsupportedLanguageDeclension extends ArticledDeclension {
                 return isPlural ? (plural != null ? plural : singular) : singular;
             }
 
-
-
-			@Override
-			public String getString(NounForm form) {
+            @Override
+            public String getString(NounForm form) {
                 assert form instanceof PersianNounForm : "Persian only: " + form;
                 return form.getCase() == LanguageCase.ACCUSATIVE ? form.getNumber() == LanguageNumber.PLURAL ? plural_acc : singular_acc
                         : form.getNumber() == LanguageNumber.PLURAL ? plural : singular;
             }
+
             @Override
             public void setString(String value, NounForm form) {
                 if (form.getCase() == LanguageCase.ACCUSATIVE) {
@@ -469,6 +477,7 @@ abstract class UnsupportedLanguageDeclension extends ArticledDeclension {
                     }
                 }
             }
+
             @Override
             protected boolean validateValues(String name, LanguageCase _case) {
                 if (this.singular == null) {
@@ -489,6 +498,16 @@ abstract class UnsupportedLanguageDeclension extends ArticledDeclension {
                     }
                 }
                 return true;
+            }
+
+            @Override
+            protected Object readResolve() {
+                super.readResolve();
+                this.singular = intern(this.singular);
+                this.plural = intern(this.plural);
+                this.singular_acc = intern(this.singular_acc);
+                this.plural_acc = intern(this.plural_acc);
+                return this;
             }
         }
 
@@ -516,40 +535,39 @@ abstract class UnsupportedLanguageDeclension extends ArticledDeclension {
             return EnumSet.of(LanguageCase.NOMINATIVE, LanguageCase.ACCUSATIVE);
         }
 
-		@Override
-		public boolean hasStartsWith() {
-			return false;
-		}
+        @Override
+        public boolean hasStartsWith() {
+            return false;
+        }
 
         @Override
         public boolean hasGender() {
             return false;
         }
 
-		@Override
-		public Collection<? extends NounForm> getEntityForms() {
-			return getAllNounForms();
-		}
+        @Override
+        public Collection<? extends NounForm> getEntityForms() {
+            return getAllNounForms();
+        }
 
-		@Override
-		public Collection<? extends NounForm> getFieldForms() {
-			return FA_SING_FORMS;
-		}
+        @Override
+        public Collection<? extends NounForm> getFieldForms() {
+            return FA_SING_FORMS;
+        }
 
-		@Override
-		public Collection<? extends NounForm> getOtherForms() {
-			return FA_SING_FORMS;
-		}
+        @Override
+        public Collection<? extends NounForm> getOtherForms() {
+            return FA_SING_FORMS;
+        }
 
-		@Override
-		public List<? extends AdjectiveForm> getAdjectiveForms() {
-			return SimpleDeclension.ADJECTIVE_FORMS;
-		}
+        @Override
+        public List<? extends AdjectiveForm> getAdjectiveForms() {
+            return SimpleDeclension.ADJECTIVE_FORMS;
+        }
 
-		@Override
-		public Adjective createAdjective(String name, LanguageStartsWith startsWith, LanguagePosition position) {
-			return new SimpleAdjective(this, name);
-		}
+        @Override
+        public Adjective createAdjective(String name, LanguageStartsWith startsWith, LanguagePosition position) {
+            return new SimpleAdjective(this, name);
+        }
     }
-
 }

--- a/src/main/java/com/force/i18n/grammar/parser/AdjectiveRefTag.java
+++ b/src/main/java/com/force/i18n/grammar/parser/AdjectiveRefTag.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -12,7 +12,7 @@ import com.force.i18n.grammar.GrammaticalTerm.TermType;
 
 /**
  * Represents a fully qualified adjective reference.
- * 
+ *
  * @author stamm
  */
 class AdjectiveRefTag extends ModifierRefTag {
@@ -59,5 +59,10 @@ class AdjectiveRefTag extends ModifierRefTag {
     @Override
     protected NounModifier resolveModifier(LanguageDictionary dictionary) {
         return dictionary.getAdjective(getName());
+    }
+
+    @Override
+    AdjectiveRefTag unique() {
+        return tagMap.unique(this);
     }
 }

--- a/src/main/java/com/force/i18n/grammar/parser/ArticleRefTag.java
+++ b/src/main/java/com/force/i18n/grammar/parser/ArticleRefTag.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -48,7 +48,7 @@ class ArticleRefTag extends ModifierRefTag {
     protected NounModifier resolveModifier(LanguageDictionary dictionary) {
         return dictionary.getArticle(getName());
     }
-    
+
 	@Override
     public String toJson(LanguageDictionary dictionary, List<?> list) {
 		// Fallback labels can have articles, but they should be ignored
@@ -58,4 +58,8 @@ class ArticleRefTag extends ModifierRefTag {
 		return super.toJson(dictionary, list);
 	}
 
+    @Override
+    ArticleRefTag unique() {
+        return tagMap.unique(this);
+    }
 }

--- a/src/main/java/com/force/i18n/grammar/parser/ConcurrentUniquefy.java
+++ b/src/main/java/com/force/i18n/grammar/parser/ConcurrentUniquefy.java
@@ -1,12 +1,13 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
 package com.force.i18n.grammar.parser;
 
+import java.io.Serializable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -15,7 +16,7 @@ import java.util.concurrent.ConcurrentMap;
  * "unique", but close enough to prevent leakage.  Use this for fixed-set caches.
  * @author stamm
  */
-public class ConcurrentUniquefy<T> {
+public class ConcurrentUniquefy<T> implements Serializable {
 
     private final ConcurrentMap<T, T> pool;
 
@@ -34,10 +35,10 @@ public class ConcurrentUniquefy<T> {
      */
     public T unique(T value) {
         if (value == null) return null;
-        
+
         T result = this.pool.get(value);
         if (result != null) return result;
-        
+
         result = this.pool.putIfAbsent(value, value);
         assert result == null || result.equals(value) : "There's a flaw in the equals logic associated with " + value.getClass();
         return result == null ? value : result;

--- a/src/main/java/com/force/i18n/grammar/parser/GrammaticalLabelSetFileCacheLoader.java
+++ b/src/main/java/com/force/i18n/grammar/parser/GrammaticalLabelSetFileCacheLoader.java
@@ -35,8 +35,8 @@ public class GrammaticalLabelSetFileCacheLoader extends GrammaticalLabelSetLoade
 
     private final File cacheDir;
 
-    private File calculateCacheDir(String setName) {
-    	File result = new File(I18nJavaUtil.getCacheBaseDir(), I18nJavaUtil.getProperty("cacheDir") + "/" + setName);
+    private File calculateCacheDir(String dir, String setName) {
+    	File result = new File(I18nJavaUtil.getCacheBaseDir(), Path.of(dir, setName).toString());
     	try {
     	    result = result.getCanonicalFile();
     	    if (!result.mkdirs()) {
@@ -48,6 +48,11 @@ public class GrammaticalLabelSetFileCacheLoader extends GrammaticalLabelSetLoade
     	return result;
     }
 
+    public GrammaticalLabelSetFileCacheLoader(LabelSetLoaderConfig config) {
+        super(config);
+        cacheDir = calculateCacheDir(config.getCacheDir().toString(), config.getDescriptor().getLabelSetName());
+    }
+
     /**
      * Construct a FileCacheLoader that will cache the label set values
      * in the
@@ -55,8 +60,7 @@ public class GrammaticalLabelSetFileCacheLoader extends GrammaticalLabelSetLoade
      * @param parent the optional parent provider for fallback labels
      */
     public GrammaticalLabelSetFileCacheLoader(GrammaticalLabelSetDescriptor desc, GrammaticalLabelSetProvider parent) {
-        super(desc, parent);
-        cacheDir = calculateCacheDir(desc.getLabelSetName());
+        this(new LabelSetLoaderConfig(desc, parent));
     }
 
     // Used for testing

--- a/src/main/java/com/force/i18n/grammar/parser/LabelSetLoaderConfig.java
+++ b/src/main/java/com/force/i18n/grammar/parser/LabelSetLoaderConfig.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.force.i18n.grammar.parser;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.MissingResourceException;
+
+import com.force.i18n.I18nJavaUtil;
+import com.force.i18n.LanguageLabelSetDescriptor.GrammaticalLabelSetDescriptor;
+import com.force.i18n.grammar.GrammaticalLabelSetProvider;
+import com.force.i18n.settings.BasePropertyFile;
+
+public class LabelSetLoaderConfig {
+    public static final String CACHE_DIR = "cacheDir";
+    public static final String USE_TRANSLATED_LANG = "useTranslatedLanguage";
+    public static final String SKIP_PARSING_PLATFORM = "skipParsingLabelForPlatformLanguage";
+    public static final String RECORD_STATS = "loader.cache.stats";
+    public static final String LOADER_EXPIRE_AFTER = "loader.cache.expireAfter";
+    public static final String LOADER_MAX_SIZE = "loader.cache.maxSize";
+
+    private final GrammaticalLabelSetDescriptor desc;
+    private final GrammaticalLabelSetProvider parent;
+
+    private Path cacheDir;
+    private boolean useTranslatedLanguage;
+    private boolean skipParsingLabelForPlatform;
+    private boolean isCacheStatsEnabled;
+    private Duration cacheExpireAfter; // expiration in minues
+    private long cacheMaxSize; // max allowed entires
+
+    public LabelSetLoaderConfig(GrammaticalLabelSetDescriptor baseDesc, GrammaticalLabelSetProvider parent) {
+        this.desc = baseDesc;
+        this.parent = parent;
+
+        // setup defaults from properties
+        setCacheDir(Path.of(getProperty(CACHE_DIR)));
+        setTranslatedLanguage(BasePropertyFile.stringToBoolean(getProperty(USE_TRANSLATED_LANG)));
+        setSkipParsingLabelForPlatform(BasePropertyFile.stringToBoolean(getProperty(SKIP_PARSING_PLATFORM)));
+        setCacheStatsEnabled(BasePropertyFile.stringToBoolean(getProperty(RECORD_STATS)));
+        setCacheExpireAfter(Duration.ofMinutes(getPropertyLong(LOADER_EXPIRE_AFTER)));
+        setCacheMaxSize(getPropertyLong(LOADER_MAX_SIZE));
+    }
+
+    public LabelSetLoaderConfig(LabelSetLoaderConfig copyFrom) {
+        this(copyFrom.getDescriptor(), copyFrom.getParent());
+
+        setCacheDir(copyFrom.getCacheDir());
+        setTranslatedLanguage(copyFrom.useTranslatedLanguage());
+        setSkipParsingLabelForPlatform(copyFrom.skipParsingLabelForPlatform());
+        setCacheStatsEnabled(copyFrom.isCacheStatsEnabled());
+        setCacheExpireAfter(copyFrom.getCacheExpireAfter());
+        setCacheMaxSize(copyFrom.getCacheMaxSize());
+    }
+
+    public static String getProperty(String prop) {
+        try {
+            return I18nJavaUtil.getProperty(prop);
+        } catch (MissingResourceException ignore) {
+            return null;
+        }
+    }
+
+    public static long getPropertyLong(String prop) {
+        String s = getProperty(prop);
+        try {
+            return Long.valueOf(s);
+        } catch (NumberFormatException ignore) {
+            return 0;
+        }
+    }
+
+    public GrammaticalLabelSetDescriptor getDescriptor() {
+        return this.desc;
+    }
+
+    public GrammaticalLabelSetProvider getParent() {
+        return this.parent;
+    }
+
+    public LabelSetLoaderConfig setCacheDir(Path dir) {
+        this.cacheDir = dir;
+        return this;
+    }
+    public Path getCacheDir() {
+        return this.cacheDir;
+    }
+
+    public LabelSetLoaderConfig setTranslatedLanguage(boolean newValue) {
+        this.useTranslatedLanguage = newValue;
+        return this;
+    }
+
+    public boolean useTranslatedLanguage() {
+        return useTranslatedLanguage;
+    }
+
+    public LabelSetLoaderConfig setSkipParsingLabelForPlatform(boolean newValue) {
+        this.skipParsingLabelForPlatform = newValue;
+        return this;
+    }
+
+    public boolean skipParsingLabelForPlatform() {
+        return this.skipParsingLabelForPlatform;
+    }
+
+    public boolean isCacheStatsEnabled() {
+        return this.isCacheStatsEnabled;
+    }
+
+    public LabelSetLoaderConfig setCacheStatsEnabled(boolean newVal) {
+        this.isCacheStatsEnabled = newVal;
+        return this;
+    }
+
+    public Duration getCacheExpireAfter() {
+        return this.cacheExpireAfter;
+    }
+
+    public LabelSetLoaderConfig setCacheExpireAfter(Duration newVal) {
+        this.cacheExpireAfter = newVal;
+        return this;
+    }
+
+    public long getCacheMaxSize() {
+        return this.cacheMaxSize;
+    }
+
+    public LabelSetLoaderConfig setCacheMaxSize(long newVal) {
+        this.cacheMaxSize = newVal < 0 ? 0 : newVal;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("stats=").append(this.isCacheStatsEnabled)
+                .append(", expire=").append(this.cacheExpireAfter)
+                .append(", size=").append(this.cacheMaxSize);
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/force/i18n/grammar/parser/NounRefTag.java
+++ b/src/main/java/com/force/i18n/grammar/parser/NounRefTag.java
@@ -219,4 +219,9 @@ class NounRefTag extends TermRefTag {
         }
         return n;
     }
+
+    @Override
+    NounRefTag unique() {
+        return tagMap.unique(this);
+    }
 }

--- a/src/main/java/com/force/i18n/grammaticus.properties
+++ b/src/main/java/com/force/i18n/grammaticus.properties
@@ -27,6 +27,7 @@ cacheLabelSets=true
 
 # Where to store the cache.
 cacheDir=target/ncache
+
 #
 # Contains a comma separated set of section names that are OK to not be translated.
 nonTranslatedSections=UiSkin,LanguageName
@@ -37,3 +38,17 @@ failOnMissingDeclension=true
 # Whether to respect HumanLanguage.isTranslatedLanguage() and skip unnecessary parsing for better performance.
 # Set to false for the original behavior (that tries to parse labels for any language)
 useTranslatedLanguage=false
+
+# if true, parser loads dictionary but skips parsing label file (labels.xml)
+# Only used for platform langauge that has unique declension (e.g. haw) and useTranslatedLanguage=true.
+skipParsingLabelForPlatformLanguage=false
+
+# GrammaticalLabelSetLoader:
+# enable cache stats
+loader.cache.stats=false
+
+# expiration after access in minute. never expires for 0.
+loader.cache.expireAfter=0
+
+# maximum size of cache entry. This cache key is LabelSetDescriptor(language). no limit for 0.
+loader.cache.maxSize=0

--- a/src/main/java/com/force/i18n/settings/BasePropertyFile.java
+++ b/src/main/java/com/force/i18n/settings/BasePropertyFile.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -37,18 +37,18 @@ import com.force.i18n.commons.util.settings.SettingsUtil;
  * Values may also contain references to system parameters.
  * <h3> Example </h3>
  * <pre><code>
- *                                     &lt;section name=&quot;sectionName&quot;&gt;
- *
- *                                         &lt;!--  Standard Parameter --&gt;
- *                                         &lt;param name=&quot;paramName1&quot;&gt; paramValue &lt;/param&gt;
- *
- *                                         &lt;!--  Parameter Reference --&gt;
- *                                         &lt;param name=&quot;paramName2&quot;&gt; ${sectionName.paramName1} &lt;/param&gt;
- *
- *                                         &lt;!--  Property Reference --&gt;
- *                                         &lt;param name=&quot;paramName3&quot;&gt; #{user.property} &lt;/param&gt;
- *
- *                                     &lt;/section&gt;
+*  &lt;section name=&quot;sectionName&quot;&gt;
+*
+*      &lt;!--  Standard Parameter --&gt;
+*      &lt;param name=&quot;paramName1&quot;&gt; paramValue &lt;/param&gt;
+*
+*      &lt;!--  Parameter Reference --&gt;
+*      &lt;param name=&quot;paramName2&quot;&gt; ${sectionName.paramName1} &lt;/param&gt;
+*
+*      &lt;!--  Property Reference --&gt;
+*      &lt;param name=&quot;paramName3&quot;&gt; #{user.property} &lt;/param&gt;
+*
+*  &lt;/section&gt;
  * </code></pre>
  *
  * @author nveeser, btsai
@@ -79,7 +79,7 @@ public class BasePropertyFile implements BaseNonConfigIniFile, Serializable {
 
     protected BasePropertyFile(int initialCapacity, PropertyFileData data) {
         this.data = data;
-        this.metaData = new HashMap<String, Map<String, MetaDataInfo>>(initialCapacity);
+        this.metaData = new HashMap<>(initialCapacity);
     }
 
     public BasePropertyFile(Parser p) throws IOException {
@@ -181,7 +181,7 @@ public class BasePropertyFile implements BaseNonConfigIniFile, Serializable {
      * @param baseParam the prefix for all the keys in the label section.
      */
     private List<String> getParamList(String section, String baseParam) {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         for (int index = 0; true; ++index) {
             String result = getString(section, makeListEntryParam(baseParam, index), null);
             if (result == null) {
@@ -228,17 +228,17 @@ public class BasePropertyFile implements BaseNonConfigIniFile, Serializable {
     }
 
     protected Object inner_get(String section, String param, boolean throwSettingsSectionNotFoundException) throws SettingsSectionNotFoundException {
-        Map<String, Object> theSect = this.data.getSection(section);
-        if (theSect == null) {
+        if (!containsSection(section)) {
             if (throwSettingsSectionNotFoundException) {
                 throw new SettingsSectionNotFoundException("PropertyFile - section " + section + " not found.");
             }
             return null;
         }
+
         if (param == null) {
             throw new NullPointerException();
         }
-        return theSect.get(param);
+        return this.data.get(section, param);
     }
 
     /**
@@ -386,7 +386,7 @@ public class BasePropertyFile implements BaseNonConfigIniFile, Serializable {
 
     @Override
     public boolean getBoolean(String section, String param, boolean ifNull) {
-        if (ifNull == true) {
+        if (ifNull) {
             return stringToBoolean(getString(section, param, "true"));
         }
         return stringToBoolean(getString(section, param, "false"));
@@ -540,7 +540,7 @@ public class BasePropertyFile implements BaseNonConfigIniFile, Serializable {
      * @param sectionName the section of the param being replace
      * @param paramName the key of the param being replace
      * @param val the value being replaced
-     * @param referenceConfig an object being passed in to parsing for 
+     * @param referenceConfig an object being passed in to parsing for
      * @return the val with substrings substituted if need be
      * @throws IOException in case there are any IO Exceptions
      * @throws SubstitutionException in case the val has a malformed section/param
@@ -633,12 +633,13 @@ public class BasePropertyFile implements BaseNonConfigIniFile, Serializable {
 
         @Override
         public boolean equals(Object o) {
-            if (o == null || !(o instanceof MetaDataInfo)) {
-                return false;
+            if (this == o) return true;
+            if (o instanceof MetaDataInfo) {
+                MetaDataInfo mdi = (MetaDataInfo)o;
+                return this.locator.equals(mdi.locator) && this.sourceFile.equals(mdi.sourceFile)
+                        && this.deprecated == mdi.deprecated;
             }
-            MetaDataInfo mdi = (MetaDataInfo)o;
-            return this.locator.equals(mdi.locator) && this.sourceFile.equals(mdi.sourceFile)
-                && this.deprecated == mdi.deprecated;
+            return false;
         }
 
         @Override
@@ -661,14 +662,10 @@ public class BasePropertyFile implements BaseNonConfigIniFile, Serializable {
      *   @return the booleanValue string as a boolean
      */
     public static boolean stringToBoolean(String booleanValue) {
-        if("1".equals(booleanValue)
+        return "1".equals(booleanValue)
                 || "true".equals(booleanValue)
                 || "yes".equals(booleanValue)
-                || "on".equals(booleanValue)) {
-            return true;
-        }
-
-        return false;
+                || "on".equals(booleanValue);
     }
 
     /**

--- a/src/main/java/com/force/i18n/settings/PropertyFileData.java
+++ b/src/main/java/com/force/i18n/settings/PropertyFileData.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -110,4 +110,14 @@ public interface PropertyFileData extends Serializable {
      */
     void shareKeys(SharedKeyMap<String, SharedKeyMap<String, Object>> seedKeyMap);
 
+    /**
+     * @param sectionName the section name
+     * @param paramName the parameter name
+     * @return a raw label value as {@code Object} for the a particular {@code sectionName} and {@code paramName} or
+     * {@code null} if the {@code sectionName} or {@code paramName} does not exist.
+     */
+    default Object get(String sectionName, String paramName) {
+        Map<String, Object> section = getSection(sectionName);
+        return section == null ? null : section.get(paramName);
+    }
 }

--- a/src/test/java/com/force/i18n/grammar/parser/GrammaticalLabelSerializationTest.java
+++ b/src/test/java/com/force/i18n/grammar/parser/GrammaticalLabelSerializationTest.java
@@ -1,17 +1,19 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
 package com.force.i18n.grammar.parser;
 
 import java.io.*;
+import java.util.List;
 import java.util.logging.Logger;
 
 import com.force.i18n.*;
 import com.force.i18n.grammar.GrammaticalLabelSet;
+import com.force.i18n.grammar.Noun;
 import com.google.common.collect.ImmutableList;
 
 /**
@@ -33,7 +35,6 @@ public class GrammaticalLabelSerializationTest extends BaseGrammaticalLabelTest 
      * NOTE that the label set for fully-supported languages can also be retrieved from the
      * Localizer
      */
-
 
     public void testSerializeDictionary() throws Exception {
         GrammaticalLabelSetLoader loader = getLoader();
@@ -67,6 +68,31 @@ public class GrammaticalLabelSerializationTest extends BaseGrammaticalLabelTest 
                 // Make sure the noun forms are the same
 
                 assertEquals("Serialized labels aren't the same", labelSet.getSection("ModStamp"), copy.getSection("ModStamp"));
+
+                // test deserialized object still refers to the same object (uniquefied)
+                Noun srcNoun = labelSet.getDictionary().getNoun("account", false);
+                Noun copyNoun = copy.getDictionary().getNoun("account", false);
+                assertSame(srcNoun.getEntityName(), copyNoun.getEntityName());
+                assertSame(srcNoun.getPluralAlias(), copyNoun.getPluralAlias());
+                assertSame(srcNoun.getAccess(), copyNoun.getAccess());
+
+                // "Sample.click_here_to_create_new_account" refers to "{0} to create <a/> <new/> <account/> now.".  labelSet.get() returns
+                // List<?> of: ["{0} to create ", <a/>, " ", <new/>, " ", <account/>, " now."]
+                Object src = labelSet.get("Sample", "click_here_to_create_new_account", null);
+                Object test = copy.get("Sample", "click_here_to_create_new_account", null);
+                assertTrue(src instanceof List<?>);
+                assertTrue(((List<?>)src).get(1) instanceof TermRefTag); // <a/>
+                assertSame(((List<?>)src).get(1), ((List<?>)test).get(1)); // should be the same (uniquefied)
+                assertSame(((TermRefTag)(((List<?>)src).get(1))).getName(), ((TermRefTag)(((List<?>)test).get(1))).getName());
+
+                assertTrue(((List<?>)src).get(3) instanceof TermRefTag); // <new/>
+                assertSame(((List<?>)src).get(3), ((List<?>)test).get(3)); // should be the same (uniquefied)
+                assertSame(((TermRefTag)(((List<?>)src).get(3))).getName(), ((TermRefTag)(((List<?>)test).get(3))).getName());
+
+                assertTrue(((List<?>)src).get(5) instanceof TermRefTag); // <account/>
+                assertSame(((List<?>)src).get(5), ((List<?>)test).get(5)); // should be the same (uniquefied)
+                assertSame(((TermRefTag)(((List<?>)src).get(5))).getName(), ((TermRefTag)(((List<?>)test).get(5))).getName());
+
             } finally {
                 file.delete();
             }


### PR DESCRIPTION
- add "uniquefy" (intern) call when de-serializing objects
  - add missing `equals(Object)` and `hashCode()` implementation to be used for interning values

- add `LabelSetLoaderConfig` class to override configurations from `grammaticus.properties`
  - add new constructor to `GrammaticalLabelSetLoader` that takes `LabelSetLoaderConfig`

- fixed `get(String, String)` and `inner_get(String, String, boolean)` methods to stop calling `getSection(String)`.  This is to support subclasses of `PropertyFileData` if it refers to KVS like data store such as `Map<Key, Object>` instead of `Map<String, Map<String, Object>>`.  For those classes,  calling getSection that expects returning `Map<String, Object>` is not efficient.
  - `PropertyFileData#get(String, String)`
  - `BasePropertyFile#inner_get(Strnig, String, boolean)`
  - `GrammaticalLabelSetFallbackImpl.CompositePropertyFileDataImpl#get(String, String)`

**misc changes**:
- replaced redundant generics with diamond operator (`<>`) 
- removed empty comment blocks
- removed unnecessary `static` declaration of inner-Enum class 
- hide `public` constructor of abstract class to `protected`