### PR TITLE
bump up maven-release-plugin version for JDK17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,21 +35,13 @@
         <roles>
             <role>Member</role>
         </roles>
-        <email>apoblock@salesforce.com </email>
-        <organization>Salesforce</organization>
-    </developer>
-    <developer>
-        <name>Bo Yang</name>
-        <roles>
-            <role>Member</role>
-        </roles>
-        <email>bo.yang@salesforce.com</email>
+        <email>apoblocki@salesforce.com</email>
         <organization>Salesforce</organization>
     </developer>
   </developers>
 
   <properties>
-    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <icu4j.version>69.1</icu4j.version>
     <icu4j-localespi.version>69.1</icu4j-localespi.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,11 +31,11 @@
         <organization>Salesforce</organization>
     </developer>
     <developer>
-        <name>Steven Tamm</name>
+        <name>Andrzej Poblocki</name>
         <roles>
             <role>Member</role>
         </roles>
-        <email>stamm@salesforce.com </email>
+        <email>apoblock@salesforce.com </email>
         <organization>Salesforce</organization>
     </developer>
     <developer>
@@ -49,8 +49,7 @@
   </developers>
 
   <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <icu4j.version>69.1</icu4j.version>
     <icu4j-localespi.version>69.1</icu4j-localespi.version>
@@ -113,7 +112,7 @@
                     the BSD 3-Clause license. For full license text, see the LICENSE.txt file in the
                     repository.
                 </bottom>
-                <additionalparam>-Xdoclint:none</additionalparam>
+                <doclint>none</doclint>
             </configuration>
             <executions>
                 <execution>
@@ -136,7 +135,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.0.1</version>
             <configuration>
               <!-- Prevent gpg from using pinentry programs -->
               <gpgArguments>
@@ -153,7 +152,7 @@
                 </goals>
               </execution>
             </executions>
-	  </plugin>
+          </plugin>
         </plugins>
       </build>
     </profile>
@@ -235,7 +234,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.3</version>
+        <version>3.0.0</version>
         <configuration>
           <autoVersionSubmodules>true</autoVersionSubmodules>
           <useReleaseProfile>false</useReleaseProfile>
@@ -262,9 +261,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.1.1</version>
-		<configuration>
-		  <doclint>none</doclint>
-		</configuration>
+        <configuration>
+          <doclint>none</doclint>
+        </configuration>
       </plugin>
     </plugins>
   </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,10 @@
       <build>
         <plugins>
           <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.11.0</version>
+          </plugin>
+          <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <version>3.0.0-M8</version>
             <configuration>


### PR DESCRIPTION
trying to fix `maven-release-plugin` [failure](https://github.com/salesforce/grammaticus/actions/runs/4849990583/jobs/8642494462).

confirmed locally by running `mvn release:prepare -DdryRun`. let's see if this works.
