### PR TITLE
update nexus-staging-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.7</version>
+            <version>1.6.13</version>
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>


### PR DESCRIPTION
Sonatype `nexus-staging-maven-plugin` has an issue with JDK 17 ([NEXUS-26993](https://issues.sonatype.org/browse/NEXUS-26993)) and requires the newer version