### PR TITLE
fix NPE

### DIFF
--- a/src/main/java/com/force/i18n/grammar/Noun.java
+++ b/src/main/java/com/force/i18n/grammar/Noun.java
@@ -91,7 +91,9 @@ public abstract class Noun extends GrammaticalTerm implements Cloneable {
     }
 
     public final LanguageGender getGender() {
-        return this.gender;
+        // this.gender could be initialized with null if noun is only defined in root (English)
+        if (this.gender != null) return this.gender;
+        return this.getDeclension().hasGender() ? this.getDeclension().getDefaultGender() : null;
     }
 
     @Override


### PR DESCRIPTION
`Noun#getGender()` returns `null` only when `LanguageDeclension#hasGender()` is `false` otherwise, returns `LanguageDeclension#getDefaultGdner()` to avoid `NullPointerException`