### PR TITLE
Fix more serialization related code

### DIFF
--- a/src/main/java/com/force/i18n/grammar/GrammaticalTerm.java
+++ b/src/main/java/com/force/i18n/grammar/GrammaticalTerm.java
@@ -89,6 +89,10 @@ public abstract class GrammaticalTerm implements Serializable, Comparable<Gramma
 
     @Override
     public int compareTo(GrammaticalTerm o) {
+        int langComp = Integer.compare(getDeclension().getLanguage().ordinal(),
+                o.getDeclension().getLanguage().ordinal());
+        if (langComp != 0) return langComp;
+
         TermType thisType = getTermType();
         TermType oType = o.getTermType();
         int typeComp = thisType.compareTo(oType);
@@ -97,10 +101,11 @@ public abstract class GrammaticalTerm implements Serializable, Comparable<Gramma
 
     @Override
     public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) {
             return false;
+        }
 
         return compareTo((GrammaticalTerm)o) == 0;
     }

--- a/src/main/java/com/force/i18n/grammar/LanguageDictionary.java
+++ b/src/main/java/com/force/i18n/grammar/LanguageDictionary.java
@@ -69,7 +69,7 @@ public final class LanguageDictionary implements Serializable {
     public LanguageDictionary(HumanLanguage language) {
         this.language = language;
         this.declension = LanguageDeclensionFactory.get().getDeclension(language);
-        this.nounsByEntityType = HashMultimap.create();
+        this.nounsByEntityType = ArrayListMultimap.create();
     }
 
     /**
@@ -667,7 +667,7 @@ public final class LanguageDictionary implements Serializable {
 
         this.declension = LanguageDeclensionFactory.get().getDeclension(this.language);
 
-        this.nounsByEntityType = HashMultimap.create();
+        this.nounsByEntityType = ArrayListMultimap.create();
         for (Noun n : this.nounMap.values()) {
             if (n.getEntityName() != null) this.nounsByEntityType.put(intern(n.getEntityName().toLowerCase()), n);
         }

--- a/src/main/java/com/force/i18n/grammar/Noun.java
+++ b/src/main/java/com/force/i18n/grammar/Noun.java
@@ -169,7 +169,7 @@ public abstract class Noun extends GrammaticalTerm implements Cloneable {
         if (this == obj) return true;
         if (obj instanceof Noun) {
             Noun n = (Noun)obj;
-            return getName().equals(n.getName()) && equalsAttribute(n) && equalsValue(n);
+            return super.equals(n) && equalsAttribute(n) && equalsValue(n);
         }
         return false;
     }

--- a/src/main/java/com/force/i18n/grammar/impl/ComplexGrammaticalForm.java
+++ b/src/main/java/com/force/i18n/grammar/impl/ComplexGrammaticalForm.java
@@ -549,7 +549,7 @@ abstract class ComplexGrammaticalForm implements Serializable, Comparable<Comple
 
         @Override
         public void setString(String value, NounForm form) {
-            values.put(getFormClass().cast(form), value);
+            values.put(getFormClass().cast(form), intern(value));
         }
 
         @Override
@@ -611,7 +611,7 @@ abstract class ComplexGrammaticalForm implements Serializable, Comparable<Comple
 
         @Override
         public void setString(String value, NounForm form) {
-            values.put(getFormClass().cast(form), value);
+            values.put(getFormClass().cast(form), intern(value));
         }
 
         @Override

--- a/src/main/java/com/force/i18n/grammar/impl/HebrewDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/HebrewDeclension.java
@@ -165,10 +165,10 @@ class HebrewDeclension extends SemiticDeclension {
                 }
                 // Default the singular/plural definitions to start
                 if (this.singular_def == null) {
-                    this.singular_def = DEFAULT_DEFINITE_PREFIX + this.singular;
+                    this.singular_def = intern(DEFAULT_DEFINITE_PREFIX + this.singular);
                 }
                 if (this.plural_def == null) {
-                    this.plural_def = DEFAULT_DEFINITE_PREFIX + this.plural;
+                    this.plural_def = intern(DEFAULT_DEFINITE_PREFIX + this.plural);
                 }
             }
             return true;


### PR DESCRIPTION
- Fixed `LanguageDictionary#nounsByEntityType` to use `ArrayListMultimap` that was accidentally replaced with `HashMultimap` in #38.  The `HashMultimap`  uses too much memory than expected.
- Fixed incomplete `#equals(Object)` implementation in `Noun` and `GrammaticalTerm` class
- Fixed missing `IniFileUtil#intern(String)` call in `ComplexGrammaticalForm` and `HebrewDeclension`