### PR TITLE
Use GrammaticalTermMap instead of raw Map in LanguageDictionary.

### DIFF
--- a/src/main/java/com/force/i18n/grammar/GrammaticalTermMap.java
+++ b/src/main/java/com/force/i18n/grammar/GrammaticalTermMap.java
@@ -1,7 +1,7 @@
 package com.force.i18n.grammar;
 
 import java.io.IOException;
-import java.o.Serializable;
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -13,7 +13,7 @@ import java.util.Set;
  * and also sequential access won't work if the implementation is not in-memory one.
  * 
  */
-public interface GrammaticalTermMap<T extends GrammaticalTerm> implements Serializable {
+public interface GrammaticalTermMap<T extends GrammaticalTerm> extends Serializable {
 
     /**
      * Return true is skinny - immutable

--- a/src/main/java/com/force/i18n/grammar/GrammaticalTermMap.java
+++ b/src/main/java/com/force/i18n/grammar/GrammaticalTermMap.java
@@ -1,0 +1,96 @@
+package com.force.i18n.grammar;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Representation of map stores any {@link GrammaticalTerm} in LanguageDictionary.
+ * Is a subset of Map but some other methods are added. 
+ * Note that, not all implementation supports all methods. Updating this would not work for isSkinny=true, 
+ * and also sequential access won't work if the implementation is not in-memory one.
+ * 
+ */
+public interface GrammaticalTermMap<T extends GrammaticalTerm> {
+
+    /**
+     * Return true is skinny - immutable
+     */
+    default boolean isSkinny() {
+        return false;
+    }
+
+    /**
+     * Run validation in the values and make it skinny
+     */
+    default void validate() {
+        for(Map.Entry<String, T> e : entrySet()) {
+            e.getValue().validate(e.getKey());
+            e.getValue().makeSkinny();
+        }
+    }
+
+    /**
+     * make it skinny - in memory or another immutable solution 
+     * @return
+     */
+    GrammaticalTermMap<T> makeSkinny();
+
+    /**
+     * set of keys
+     */
+    Set<String> keySet();
+
+    /**
+     * true if this key exists
+     * @param name
+     * @return
+     */
+    boolean containsKey(String name);
+        
+    /**
+     * true if empty
+     * @return
+     */
+    boolean isEmpty();
+
+    /**
+     * Get term from this map
+     * @param name
+     * @return
+     */
+    T get(String name);
+
+    /**
+     * entry set - not work if isSkinny=true.
+     */
+    void put(String k, T v);
+    
+    /**
+     * entry set - not work if isSkinny=true.
+     */
+    void putAll(GrammaticalTermMap<T> other);
+
+    /**
+     * Get all terms in this map - not work if not in-memory case.
+     */
+
+    Collection<T> values();
+
+    /**
+     * Get name - term pairs of this map - not work if not in-memory case.
+     */
+    Set<Map.Entry<String,T>> entrySet();
+    
+    /**
+     * Write as json of this map - not work if not in-memory case.
+     * 
+     * @param out
+     * @param renamingProvider
+     * @param dictionary
+     * @param termsToInclude
+     * @throws IOException
+     */
+    void writeJson(Appendable out, RenamingProvider renamingProvider, LanguageDictionary dictionary, Collection<String> termsToInclude) throws IOException;    
+}

--- a/src/main/java/com/force/i18n/grammar/GrammaticalTermMap.java
+++ b/src/main/java/com/force/i18n/grammar/GrammaticalTermMap.java
@@ -1,6 +1,7 @@
 package com.force.i18n.grammar;
 
 import java.io.IOException;
+import java.o.Serializable;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -12,7 +13,7 @@ import java.util.Set;
  * and also sequential access won't work if the implementation is not in-memory one.
  * 
  */
-public interface GrammaticalTermMap<T extends GrammaticalTerm> {
+public interface GrammaticalTermMap<T extends GrammaticalTerm> implements Serializable {
 
     /**
      * Return true is skinny - immutable

--- a/src/main/java/com/force/i18n/grammar/LanguageDictionary.java
+++ b/src/main/java/com/force/i18n/grammar/LanguageDictionary.java
@@ -14,15 +14,16 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.function.BiConsumer;
 
 import com.force.i18n.HumanLanguage;
 import com.force.i18n.Renameable;
 import com.force.i18n.commons.text.TextUtil;
 import com.force.i18n.commons.text.Uniquefy;
-import com.force.i18n.commons.util.collection.MapSerializer;
 import com.force.i18n.grammar.GrammaticalTerm.TermType;
 import com.force.i18n.grammar.Noun.NounType;
 import com.force.i18n.grammar.impl.LanguageDeclensionFactory;
+import com.force.i18n.grammar.impl.GrammaticalTermMapImpl;
 import com.force.i18n.grammar.parser.RefTag;
 import com.google.common.base.Supplier;
 import com.google.common.collect.*;
@@ -39,21 +40,23 @@ import com.google.common.collect.*;
  * @author yoikawa,stamm
  * @see com.force.i18n.LabelSet
  */
-public final class LanguageDictionary implements Serializable {
+public class LanguageDictionary implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private final HumanLanguage language;
     private transient LanguageDeclension declension;  // Details about noun structure
 
     // TODO: These could all be made lists when serialized
+
     // map to Noun
-    private transient Map<String, Noun> nounMap = new HashMap<>();
+    protected GrammaticalTermMap<Noun> nounMap; 
     // map to Noun
-    private transient Map<String, Noun> nounMapByPluralAlias = new HashMap<>();
+    protected GrammaticalTermMap<Noun>  nounMapByPluralAlias;
     // map to Adjective
-    private transient Map<String, Adjective> adjectiveMap = new HashMap<>();
+    protected GrammaticalTermMap<Adjective> adjectiveMap;
     // map to Article
-    private transient Map<String, Article> articleMap = new HashMap<>();
+    protected GrammaticalTermMap<Article> articleMap;
+
     // Override of noun to nounOverrides
     private SortedSetMultimap<Noun, NounVersionOverride> nounVersionOverrides;
     // Whether or not we've been "made skinny".
@@ -70,6 +73,7 @@ public final class LanguageDictionary implements Serializable {
         this.language = language;
         this.declension = LanguageDeclensionFactory.get().getDeclension(language);
         this.nounsByEntityType = ArrayListMultimap.create();
+        createGrammaticalTermMap();
     }
 
     /**
@@ -90,6 +94,13 @@ public final class LanguageDictionary implements Serializable {
         this.articleMap = from.articleMap;
         this.nounVersionOverrides = from.nounVersionOverrides;
         this.isSkinny = from.isSkinny;
+    }
+
+    protected void createGrammaticalTermMap() {
+        this.nounMap = new GrammaticalTermMapImpl<Noun>();
+        this.nounMapByPluralAlias = new GrammaticalTermMapImpl<Noun>();
+        this.adjectiveMap = new GrammaticalTermMapImpl<Adjective>();
+        this.articleMap = new GrammaticalTermMapImpl<Article>();
     }
 
     @Override
@@ -156,19 +167,64 @@ public final class LanguageDictionary implements Serializable {
         return createNoun(name, null, type, tableEnumOrId, starts, gen, null, false, false);
     }
 
-    private Map<String,? extends GrammaticalTerm> getTermMap(TermType type) {
-        switch (type) {
-        case Noun: return this.nounMap;
-        case Adjective: return this.adjectiveMap;
-        case Article: return this.articleMap;
-        }
-///CLOVER:OFF
-        throw new AssertionError("Invalid term type");
-///CLOVER:ON
+    /**
+     * get termMap of Noun
+     */
+    public GrammaticalTermMap<Noun> getNounMap() {
+        return nounMap;
     }
 
+    /**
+     * get termMap of NounByPluralAlias
+     */
+    public GrammaticalTermMap<Noun> getNounByPluralAlias() {
+        return nounMapByPluralAlias;
+    }
+
+    /**
+     * get termMap of Adjective
+     */
+    public GrammaticalTermMap<Adjective> getAdjectiveMap() {
+        return adjectiveMap;
+    }
+    
+    /**
+     * get termMap of Article 
+     */
+    public GrammaticalTermMap<Article> getArticleMap() {
+        return articleMap;
+    }
+
+
+    private void forAllTerms (TermType type, BiConsumer<String, GrammaticalTerm> f) {
+        switch (type) {
+        case Noun: 
+            for(Map.Entry<String, Noun> e : nounMap.entrySet()) f.accept(e.getKey(), e.getValue());
+            break;
+        case Adjective: 
+            for(Map.Entry<String, Adjective> e : adjectiveMap.entrySet()) f.accept(e.getKey(), e.getValue());
+            break;
+        case Article:
+            for(Map.Entry<String, Article> e : articleMap.entrySet()) f.accept(e.getKey(), e.getValue());
+            break;
+        default:
+            throw new AssertionError("Invalid term type " + type);
+        }
+    }
+    
+
+
     public Set<String> getAllTermNames(TermType type) {
-        return Collections.unmodifiableSet(getTermMap(type).keySet());
+        switch (type) {
+        case Noun: 
+            return Collections.unmodifiableSet(nounMap.keySet());
+        case Adjective: 
+            return Collections.unmodifiableSet(adjectiveMap.keySet());
+        case Article:
+            return Collections.unmodifiableSet(articleMap.keySet());
+        default:
+            throw new AssertionError("Invalid term type");
+        }
     }
 
     /**
@@ -176,11 +232,10 @@ public final class LanguageDictionary implements Serializable {
      * @return the names of all the terms of the given type that are copied from the default language
      */
     public Set<String> getAllInheritedTermNames(TermType type) {
-        Map<String, ? extends GrammaticalTerm> terms = getTermMap(type);
         Set<String> result = new HashSet<String>();
-        for (Map.Entry<String, ? extends GrammaticalTerm> term : terms.entrySet()) {
-            if (term.getValue().isCopiedFromDefault()) result.add(term.getKey());
-        }
+        forAllTerms(type, (k,v) -> {
+            if (v.isCopiedFromDefault()) result.add(k);            
+        });                
         return result;
     }
 
@@ -387,21 +442,9 @@ public final class LanguageDictionary implements Serializable {
 
     // validate all modifiers
     public void validateAll() {
-        for (Map.Entry<String, Noun> e : nounMap.entrySet()) {
-            e.getValue().validate(e.getKey());
-            e.getValue().makeSkinny();
-        }
-
-        for (Map.Entry<String, Adjective> e : adjectiveMap.entrySet()) {
-            e.getValue().validate(e.getKey());
-            e.getValue().makeSkinny();
-        }
-
-        for (Map.Entry<String, Article> e : articleMap.entrySet()) {
-            e.getValue().validate(e.getKey());
-            e.getValue().makeSkinny();
-        }
-
+        nounMap.validate();
+        adjectiveMap.validate();
+        articleMap.validate();
         if (this.nounVersionOverrides != null) {
             for (NounVersionOverride nvo : this.nounVersionOverrides.values()) {
                 nvo.getNoun().validate(nvo.getNoun().getName());
@@ -581,8 +624,25 @@ public final class LanguageDictionary implements Serializable {
      * @param termsToInclude optional set of term to include, if omitted all terms are included
      * @throws IOException if an error happens during append
      */
+    /**
+     * Write the grammatical terms associated with the given terms
+     * @param appendable the appendable to write to
+     * @param useRenamedNouns if true, use the renamed nouns instead of the default ones.  If you're doing work around
+     *        renaming nouns, you often want to pass in false for this
+     * @param termsToInclude optional set of term to include, if omitted all terms are included
+     * @throws IOException if an error happens during append
+     */
     public void writeJson(Appendable appendable, boolean useRenamedNouns, Collection<String> termsToInclude) throws IOException {
-        writeJsonTerms(appendable, useRenamedNouns, termsToInclude != null ? termsToInclude.stream().map(a->getTerm(a)).collect(Collectors.toList()) : null);
+        RenamingProvider renamingProvider = useRenamedNouns ? RenamingProviderFactory.get().getProvider() : null;
+        appendable.append("{\"n\":");
+        nounMap.writeJson(appendable, renamingProvider, this, termsToInclude);
+        appendable.append(",\"a\":");
+        adjectiveMap.writeJson(appendable, renamingProvider, this, termsToInclude);
+        if (!this.articleMap.isEmpty()) {
+            appendable.append(",\"d\":");
+            articleMap.writeJson(appendable, renamingProvider, this, termsToInclude);
+        }
+        appendable.append("}");
     }
 
     /**
@@ -593,88 +653,40 @@ public final class LanguageDictionary implements Serializable {
      * @param termsToInclude optional set of term to include, if omitted all terms are included
      * @throws IOException if an error happens during append
      */
-    public void writeJsonTerms(Appendable appendable, boolean useRenamedNouns, Collection<? extends GrammaticalTerm> termsToInclude) throws IOException {
-        RenamingProvider renamingProvider = useRenamedNouns ? RenamingProviderFactory.get().getProvider() : null;
-        appendable.append("{\"n\":");
-        writeJsonTerms(appendable, TermType.Noun, renamingProvider, termsToInclude);
-        appendable.append(",\"a\":");
-        writeJsonTerms(appendable, TermType.Adjective, renamingProvider, termsToInclude);
-        if (!this.articleMap.isEmpty()) {
-            appendable.append(",\"d\":");
-            writeJsonTerms(appendable, TermType.Article, renamingProvider, termsToInclude);
-        }
-        appendable.append("}");
+    public void writeJsonTerms(Appendable out, boolean useRenamedNouns, Collection<GrammaticalTerm> terms) throws IOException {
+        Collection<String> termsToInclude = terms.stream().map((t)->t.getName()).collect(Collectors.toSet());
+        writeJson(out, useRenamedNouns, termsToInclude);
     }
-
-    private void writeJsonTerms(Appendable out, TermType type, RenamingProvider renamingProvider, Collection<? extends GrammaticalTerm> termsToInclude) throws IOException {
-        out.append('{');
-        if (termsToInclude != null) {
-            boolean first = true;
-            for (GrammaticalTerm term : termsToInclude) {
-                if (term == null || term.getTermType() != type) continue;
-                if (!first) {
-                    out.append(',');
-                } else {
-                    first = false;
-                }
-                writeJsonTerm(out, renamingProvider, term);
-            }
-        } else {
-            writeJsonAllTerms(out, renamingProvider, type);
-        }
-        out.append('}');
-    }
-
-    private void writeJsonAllTerms(Appendable out, RenamingProvider renamingProvider, TermType type) throws IOException {
-        boolean first = true;
-        for (GrammaticalTerm term : getTermMap(type).values()) {
-            if (!first) {
-                out.append(',');
-            } else {
-                first = false;
-            }
-            writeJsonTerm(out, renamingProvider, term);
-        }
-    }
-
-    private void writeJsonTerm(Appendable out, RenamingProvider renamingProvider, GrammaticalTerm term) throws IOException {
-        if (renamingProvider != null && term instanceof Noun && renamingProvider.useRenamedNouns()) {
-            Noun renamedNoun = renamingProvider.getRenamedNoun(getLanguage(), ((Noun)term).getName());
-            if (renamedNoun != null) term = renamedNoun;
-        }
-        out.append('\"').append(term.getName().toLowerCase()).append("\":");
-        term.toJson(out);
-    }
+    
 
     private void writeObject(ObjectOutputStream out) throws IOException {
-        makeSkinny(); // ensure it's "skinny"
-
+        makeSkinny();
         out.defaultWriteObject();
-        out.writeObject(new TermMapSerializer<>(this.nounMap));
-        out.writeObject(new TermMapSerializer<>(this.nounMapByPluralAlias));
-        out.writeObject(new TermMapSerializer<>(this.adjectiveMap));
-        out.writeObject(new TermMapSerializer<>(this.articleMap));
+        writeObjectInternal(out);
+    }
+
+    protected void writeObjectInternal(ObjectOutputStream out) throws IOException {
+        // do nothing here - for hook
     }
 
     @SuppressWarnings("unchecked")
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
 
-        this.nounMap = ((TermMapSerializer<Noun>)in.readObject()).getMap();
-        this.nounMapByPluralAlias = ((TermMapSerializer<Noun>)in.readObject()).getMap();
-        this.adjectiveMap = ((TermMapSerializer<Adjective>)in.readObject()).getMap();
-        this.articleMap = ((TermMapSerializer<Article>)in.readObject()).getMap();
-
         this.declension = LanguageDeclensionFactory.get().getDeclension(this.language);
+        this.readObjectInternal(in);
+    }
 
+    private void readObjectInternal(ObjectInputStream in) throws IOException, ClassNotFoundException {
         this.nounsByEntityType = ArrayListMultimap.create();
         for (Noun n : this.nounMap.values()) {
             if (n.getEntityName() != null) this.nounsByEntityType.put(intern(n.getEntityName().toLowerCase()), n);
         }
         this.isSkinny = true;
+        // do nothing here - for hook
     }
 
-    Noun getNounOverride(Noun n) {
+    public Noun getNounOverride(Noun n) {
         if (n == null) return null;
         if (this.nounVersionOverrides == null) return n;
         SortedSet<NounVersionOverride> overrides = this.nounVersionOverrides.get(n);
@@ -723,12 +735,10 @@ public final class LanguageDictionary implements Serializable {
      * Since {@link LanguageDictionary}'s are static, this make them a perfect candidate for {@link ImmutableSortedMap}.
      */
     public void makeSkinny() {
-        nounMap = ImmutableSortedMap.copyOf(nounMap);
-        nounMapByPluralAlias = ImmutableSortedMap.copyOf(nounMapByPluralAlias);
-        adjectiveMap = ImmutableSortedMap.copyOf(adjectiveMap);
-        articleMap = ImmutableSortedMap.copyOf(articleMap);
-
-        nounMapByPluralAlias = ImmutableSortedMap.copyOf(nounMapByPluralAlias);
+        nounMap = nounMap.makeSkinny();
+        nounMapByPluralAlias = nounMapByPluralAlias.makeSkinny();
+        adjectiveMap = adjectiveMap.makeSkinny();
+        articleMap = articleMap.makeSkinny();
         // don't convert nounsByEntityType here. it may be updated by #createNoun
 
         isSkinny = true; // Prevent adding anything to this dictionary set. By assumption, the nouns are skinny.
@@ -798,18 +808,4 @@ public final class LanguageDictionary implements Serializable {
         }
     }
 
-    static final class TermMapSerializer<T extends GrammaticalTerm> extends MapSerializer<String, T> {
-        protected TermMapSerializer(Map<String, T> map) {
-            super(map);
-        }
-
-        @Override
-        protected String internKey(String key) {
-            return intern(key);
-        }
-
-        protected Map<String, T> getMap() {
-            return super.map;
-        }
-    }
 }

--- a/src/main/java/com/force/i18n/grammar/LanguageDictionary.java
+++ b/src/main/java/com/force/i18n/grammar/LanguageDictionary.java
@@ -97,10 +97,10 @@ public class LanguageDictionary implements Serializable {
     }
 
     protected void createGrammaticalTermMap() {
-        this.nounMap = new GrammaticalTermMapImpl<Noun>();
-        this.nounMapByPluralAlias = new GrammaticalTermMapImpl<Noun>();
-        this.adjectiveMap = new GrammaticalTermMapImpl<Adjective>();
-        this.articleMap = new GrammaticalTermMapImpl<Article>();
+        this.nounMap = new GrammaticalTermMapImpl<>();
+        this.nounMapByPluralAlias = new GrammaticalTermMapImpl<>();
+        this.adjectiveMap = new GrammaticalTermMapImpl<>();
+        this.articleMap = new GrammaticalTermMapImpl<>();
     }
 
     @Override

--- a/src/main/java/com/force/i18n/grammar/impl/GrammaticalTermMapImpl.java
+++ b/src/main/java/com/force/i18n/grammar/impl/GrammaticalTermMapImpl.java
@@ -148,7 +148,7 @@ public class GrammaticalTermMapImpl<T extends GrammaticalTerm> implements Gramma
     @Override
     public void put(String k, T v) {
         if(isSkinny)
-            throw new RuntimeException("This map is not able to modify");
+            throw new IllegalStateException("This map is not able to modify");
         map.put(k,v);
     }
     
@@ -156,7 +156,7 @@ public class GrammaticalTermMapImpl<T extends GrammaticalTerm> implements Gramma
     @Override 
     public void putAll(GrammaticalTermMap<T> other) {
         if(isSkinny)
-            throw new RuntimeException("This map is not able to modify");
+            throw new IllegalStateException("This map is not able to modify");
         map.putAll(((GrammaticalTermMapImpl<T>)other).map);
     }
     

--- a/src/main/java/com/force/i18n/grammar/impl/GrammaticalTermMapImpl.java
+++ b/src/main/java/com/force/i18n/grammar/impl/GrammaticalTermMapImpl.java
@@ -150,7 +150,6 @@ public class GrammaticalTermMapImpl<T extends GrammaticalTerm> implements Gramma
      * @param in
      * @throws IOException
      */
-    @Override
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         this.map = ((TermMapSerializer<T>)in.readObject()).getMap();
     }

--- a/src/main/java/com/force/i18n/grammar/impl/GrammaticalTermMapImpl.java
+++ b/src/main/java/com/force/i18n/grammar/impl/GrammaticalTermMapImpl.java
@@ -46,11 +46,11 @@ public class GrammaticalTermMapImpl<T extends GrammaticalTerm> implements Gramma
     public boolean equals(Object obj) {
         if(obj == this) 
             return true;
-        if(!obj instanceof GrammaticalTermMapImpl) 
+        if(!(obj instanceof GrammaticalTermMapImpl)) 
             return false;
 
-            GrammatcalTermMapImpl other = (GrammatcalTermMapImpl)obj;
-        return map.isSkinny == other.isSkinny && map.equals(other.map);
+        GrammaticalTermMapImpl<T> other = (GrammaticalTermMapImpl<T>)obj;
+        return isSkinny == other.isSkinny && map.equals(other.map);
     }
 
     @Override

--- a/src/main/java/com/force/i18n/grammar/impl/GrammaticalTermMapImpl.java
+++ b/src/main/java/com/force/i18n/grammar/impl/GrammaticalTermMapImpl.java
@@ -27,10 +27,13 @@ import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
  * @author ytanida
  */
 public class GrammaticalTermMapImpl<T extends GrammaticalTerm> implements GrammaticalTermMap<T>, Serializable {
-    protected Map<String, T> map;
+    private static final long serialVersionUID = 2099717329853215271L;
+
+    protected transient Map<String, T> map;
     private boolean isSkinny = false;
+
     public GrammaticalTermMapImpl() {
-        map = new HashMap<String, T>();        
+        map = new HashMap<>();        
     }
 
     public GrammaticalTermMapImpl(Map<String, T> map, boolean isSkinny) {
@@ -49,6 +52,7 @@ public class GrammaticalTermMapImpl<T extends GrammaticalTerm> implements Gramma
         if(!(obj instanceof GrammaticalTermMapImpl)) 
             return false;
 
+        @SuppressWarnings("unchecked")
         GrammaticalTermMapImpl<T> other = (GrammaticalTermMapImpl<T>)obj;
         return isSkinny == other.isSkinny && map.equals(other.map);
     }
@@ -65,12 +69,12 @@ public class GrammaticalTermMapImpl<T extends GrammaticalTerm> implements Gramma
 
     @Override
     public GrammaticalTermMap<T> makeSkinny() {
-        return new GrammaticalTermMapImpl<T>(map, true);
+        return new GrammaticalTermMapImpl<>(map, true);
     }
 
     @Override
     public void writeJson(Appendable out, RenamingProvider renamingProvider, LanguageDictionary dictionary, Collection<String> termsToInclude) throws IOException {
-        Set<String> wrote = new HashSet<String>();
+        Set<String> wrote = new HashSet<>();
         out.append('{');
         if (termsToInclude != null) {
             boolean first = true;
@@ -166,7 +170,9 @@ public class GrammaticalTermMapImpl<T extends GrammaticalTerm> implements Gramma
      * @param in
      * @throws IOException
      */
+    @SuppressWarnings("unchecked")
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
         this.map = ((TermMapSerializer<T>)in.readObject()).getMap();
     }
 
@@ -176,7 +182,8 @@ public class GrammaticalTermMapImpl<T extends GrammaticalTerm> implements Gramma
      * @throws IOException
      */
     private void writeObject(ObjectOutputStream out) throws IOException {
-        out.writeObject(new TermMapSerializer<T>(map));
+        out.defaultWriteObject();
+        out.writeObject(new TermMapSerializer<>(map));
     }
 
     static final class TermMapSerializer<T extends GrammaticalTerm> extends MapSerializer<String, T> {

--- a/src/main/java/com/force/i18n/grammar/impl/GrammaticalTermMapImpl.java
+++ b/src/main/java/com/force/i18n/grammar/impl/GrammaticalTermMapImpl.java
@@ -1,0 +1,181 @@
+package com.force.i18n.grammar.impl;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.force.i18n.HumanLanguage;
+import com.force.i18n.commons.util.collection.MapSerializer;
+import com.force.i18n.grammar.GrammaticalTerm;
+import com.force.i18n.grammar.GrammaticalTermMap;
+import com.force.i18n.grammar.LanguageDictionary;
+import com.force.i18n.grammar.Noun;
+import com.force.i18n.grammar.RenamingProvider;
+import com.google.common.collect.ImmutableMap;
+
+import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
+
+/**
+ * In-memory version of GrammaticalTermMap
+ *
+ * @author ytanida
+ */
+public class GrammaticalTermMapImpl<T extends GrammaticalTerm> implements GrammaticalTermMap<T>, Serializable {
+    protected Map<String, T> map;
+    private boolean isSkinny = false;
+    public GrammaticalTermMapImpl() {
+        map = new HashMap<String, T>();        
+    }
+
+    public GrammaticalTermMapImpl(Map<String, T> map, boolean isSkinny) {
+        this.isSkinny = isSkinny;
+        if (isSkinny)
+            this.map = new ImmutableMap.Builder<String, T>().putAll(map).build();
+        else
+            this.map = map;
+
+    }
+    
+    @Override
+    public boolean isSkinny() {
+        return isSkinny;
+    }
+
+    @Override
+    public GrammaticalTermMap<T> makeSkinny() {
+        return new GrammaticalTermMapImpl<T>(map, true);
+    }
+
+    @Override
+    public void writeJson(Appendable out, RenamingProvider renamingProvider, LanguageDictionary dictionary, Collection<String> termsToInclude) throws IOException {
+        Set<String> wrote = new HashSet<String>();
+        out.append('{');
+        if (termsToInclude != null) {
+            boolean first = true;
+            for (String name : termsToInclude) {
+                GrammaticalTerm term = map.get(name);
+                if(term != null) {
+                    if (term instanceof Noun) term = dictionary.getNounOverride((Noun)term);
+                    if (!first) {
+                        out.append(',');
+                    } else {
+                        first = false;
+                    }
+                    writeJsonTerm(out, renamingProvider, term, dictionary.getLanguage());
+                    wrote.add(name);
+                }
+            }
+            termsToInclude.removeAll(wrote);
+        } else {
+            writeJson(out, renamingProvider, dictionary.getLanguage());
+        }
+        out.append('}');
+    }
+    
+    private void writeJson(Appendable out, RenamingProvider renamingProvider, HumanLanguage lang) throws IOException {
+        boolean first = true;
+        for (GrammaticalTerm term : map.values()) {
+            if (!first) {
+                out.append(',');
+            } else {
+                first = false;
+            }
+            writeJsonTerm(out, renamingProvider, term, lang);
+        }
+    }
+    
+    private void writeJsonTerm(Appendable out, RenamingProvider renamingProvider, GrammaticalTerm term, HumanLanguage lang) throws IOException {
+        if (renamingProvider != null && term instanceof Noun && renamingProvider.useRenamedNouns()) {
+            Noun renamedNoun = renamingProvider.getRenamedNoun(lang, ((Noun)term).getName());
+            if (renamedNoun != null) term = renamedNoun;
+        }
+        out.append('\"').append(term.getName().toLowerCase()).append("\":");
+        term.toJson(out);
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return map.keySet();
+    }
+
+    @Override
+    public T get(String name) {
+        return map.get(name);
+    }
+
+
+    @Override
+    public boolean containsKey(String name) {
+        return map.containsKey(name);
+    }
+
+    @Override
+    public Set<Map.Entry<String, T>> entrySet() {
+        return map.entrySet();
+    }
+
+    @Override
+    public Collection<T> values() {
+        return map.values();
+    }
+
+    @Override
+    public void put(String k, T v) {
+        if(isSkinny)
+            throw new RuntimeException("This map is not able to modify");
+        map.put(k,v);
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Override 
+    public void putAll(GrammaticalTermMap<T> other) {
+        if(isSkinny)
+            throw new RuntimeException("This map is not able to modify");
+        map.putAll(((GrammaticalTermMapImpl<T>)other).map);
+    }
+    
+    @Override
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    /**
+     * Override default serializer to avoid any duplicated in the serialized map.
+     * @param in
+     * @throws IOException
+     */
+    @Override
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        this.map = ((TermMapSerializer<T>)in.readObject()).getMap();
+    }
+
+    /**
+     * Override default serializer to avoid any duplicated in the serialized map.
+     * @param in
+     * @throws IOException
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        out.writeObject(new TermMapSerializer<T>(map));
+    }
+
+    static final class TermMapSerializer<T extends GrammaticalTerm> extends MapSerializer<String, T> {
+        protected TermMapSerializer(Map<String, T> map) {
+            super(map);
+        }
+
+        @Override
+        protected String internKey(String key) {
+            return intern(key);
+        }
+
+        protected Map<String, T> getMap() {
+            return super.map;
+        }
+    }
+}

--- a/src/main/java/com/force/i18n/grammar/impl/GrammaticalTermMapImpl.java
+++ b/src/main/java/com/force/i18n/grammar/impl/GrammaticalTermMapImpl.java
@@ -41,7 +41,23 @@ public class GrammaticalTermMapImpl<T extends GrammaticalTerm> implements Gramma
             this.map = map;
 
     }
-    
+
+    @Override
+    public boolean equals(Object obj) {
+        if(obj == this) 
+            return true;
+        if(!obj instanceof GrammaticalTermMapImpl) 
+            return false;
+
+            GrammatcalTermMapImpl other = (GrammatcalTermMapImpl)obj;
+        return map.isSkinny == other.isSkinny && map.equals(other.map);
+    }
+
+    @Override
+    public int hashCode() {
+        return map.hashCode() + (isSkinny ? 37 : 0);
+    }
+
     @Override
     public boolean isSkinny() {
         return isSkinny;

--- a/src/main/java/com/force/i18n/grammar/parser/GrammaticalLabelSetLoader.java
+++ b/src/main/java/com/force/i18n/grammar/parser/GrammaticalLabelSetLoader.java
@@ -208,7 +208,7 @@ public class GrammaticalLabelSetLoader implements GrammaticalLabelSetProvider {
 
             } else if (this.skipParsingLabelForPlatform) {
                 // load dictionary because this language has unique declension
-                LanguageDictionaryParser dictParser = new LanguageDictionaryParser(desc, lang, this.parentProvider);
+                LanguageDictionaryParser dictParser = new LanguageDictionaryParser(desc, createNewDictionary(lang), this.parentProvider);
                 LanguageDictionary dictionary = dictParser.getDictionary();
 
                 // use copy constructor for requested language
@@ -229,13 +229,39 @@ public class GrammaticalLabelSetLoader implements GrammaticalLabelSetProvider {
         return result;
     }
 
+    /**
+     * Ger a new LanguageDictionary instance. If need some special, override this to return a subclass of
+     * LanguageDictionary.
+     *
+     * @param language
+     *            the language     
+     */
+    protected LanguageDictionary createNewDictionary(HumanLanguage language) throws IOException {
+        // default : using default LanguageDictionary
+        return new LanguageDictionary(language);
+    }
+
+    /**
+     * Finalize the dictionary after loading. If need something special (e.g. write some data to a file), override this
+     * method.
+     * 
+     * 
+     * @param dictionary the dictionary to be finalized.
+     * @return the finalized dictionary.
+     */
+
+    protected LanguageDictionary finalizeDictionary(LanguageDictionary dictionary) throws IOException {
+        // default : do nothing
+        return dictionary;        
+    }
+
     protected GrammaticalLabelSet loadLabels(GrammaticalLabelSetDescriptor desc) throws IOException {
         HumanLanguage lang = desc.getLanguage();
 
         // dictionaries are always unique for every language because it may use different LanguageDeclension
-        LanguageDictionaryParser dictParser = new LanguageDictionaryParser(desc, lang, this.parentProvider);
-        LanguageDictionary dictionary = dictParser.getDictionary();
-
+        LanguageDictionaryParser dictParser = new LanguageDictionaryParser(desc, createNewDictionary(lang), this.parentProvider);
+        LanguageDictionary dictionary = finalizeDictionary(dictParser.getDictionary());
+    
         // all standard/end-user languages comes here. Create a parser to read from XML files.
         GrammaticalLabelFileParser parser = new GrammaticalLabelFileParser(dictionary, desc, this.parentProvider);
 

--- a/src/main/java/com/force/i18n/grammar/parser/LanguageDictionaryParser.java
+++ b/src/main/java/com/force/i18n/grammar/parser/LanguageDictionaryParser.java
@@ -59,10 +59,14 @@ public final class LanguageDictionaryParser {
      * @param parentProvider the parentProvider if this parser is for overriding labels from a different labelset
      * @throws IOException if there is a parsing exception.
      */
-    public LanguageDictionaryParser(GrammaticalLabelSetDescriptor dictDesc, HumanLanguage language, GrammaticalLabelSetProvider parentProvider) throws IOException {
-        this(new LanguageDictionary(language), dictDesc, parentProvider);
+    public LanguageDictionaryParser(GrammaticalLabelSetDescriptor dictDesc, LanguageDictionary dictionary, GrammaticalLabelSetProvider parentProvider) throws IOException {
+        this(dictionary, dictDesc, parentProvider);
         loadDictionary();
         dictionary.makeSkinny();
+    }
+
+    public LanguageDictionaryParser(GrammaticalLabelSetDescriptor dictDesc, HumanLanguage language, GrammaticalLabelSetProvider parentProvider) throws IOException {
+        this(dictDesc, new LanguageDictionary(language), parentProvider);        
     }
 
     // Private constructor used *only* to get default english values for nouns that don't otherwise exist

--- a/src/test/java/com/force/i18n/grammar/impl/GrammaticalTermMapImplTest.java
+++ b/src/test/java/com/force/i18n/grammar/impl/GrammaticalTermMapImplTest.java
@@ -29,7 +29,7 @@ public class GrammaticalTermMapImplTest extends TestCase {
      * 
      */
     public void testSimpleUpdate() throws Exception{
-        GrammaticalTermMapImpl<Noun> map = new GrammaticalTermMapImpl<Noun>();
+        GrammaticalTermMapImpl<Noun> map = new GrammaticalTermMapImpl<>();
         assertTrue(map.isEmpty());
         Noun n1 = createNoun("n1");
         Noun n2 = createNoun("n2");
@@ -47,7 +47,7 @@ public class GrammaticalTermMapImplTest extends TestCase {
      */
 
     public void testSimpleWriteJson() throws Exception {
-        GrammaticalTermMapImpl<Noun> map = new GrammaticalTermMapImpl<Noun>();
+        GrammaticalTermMapImpl<Noun> map = new GrammaticalTermMapImpl<>();
         StringBuilder sb = new StringBuilder();
         map.writeJson(sb, null, new LanguageDictionary(US), null);
         assertEquals(sb.toString(), "{}");
@@ -65,7 +65,7 @@ public class GrammaticalTermMapImplTest extends TestCase {
      * Test for makeSkinny
      */
     public void testMakeSkinny() {
-        GrammaticalTermMap<Noun> map = new GrammaticalTermMapImpl<Noun>();
+        GrammaticalTermMap<Noun> map = new GrammaticalTermMapImpl<>();
         assertFalse("Initially false", map.isSkinny());
         Noun n1 = createNoun("n1");
         map.put("one", n1);

--- a/src/test/java/com/force/i18n/grammar/impl/GrammaticalTermMapImplTest.java
+++ b/src/test/java/com/force/i18n/grammar/impl/GrammaticalTermMapImplTest.java
@@ -79,7 +79,7 @@ public class GrammaticalTermMapImplTest extends TestCase {
         try {
             map.put("two", n1);
             fail("no update allowed on skinny map");
-        } catch (RuntimeException e) {
+        } catch (IllegalStateException e) {
             // expected
         }     
     }

--- a/src/test/java/com/force/i18n/grammar/impl/GrammaticalTermMapImplTest.java
+++ b/src/test/java/com/force/i18n/grammar/impl/GrammaticalTermMapImplTest.java
@@ -7,6 +7,11 @@
 
 package com.force.i18n.grammar.impl;
 
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
 import java.util.HashSet;
 import java.util.Locale;
 import junit.framework.TestCase;
@@ -79,7 +84,62 @@ public class GrammaticalTermMapImplTest extends TestCase {
         }     
     }
 
+    @SuppressWarnings("unchecked")
+    public void testSerialization() throws Exception {
+        GrammaticalTermMapImpl<Noun> map = new GrammaticalTermMapImpl<>();
+        assertSerializedEquals(map);
+        Noun n1 = createNoun("n1");
+        map.put("one", createNoun("one"));
+        map.put("two", createNoun("two"));
+        assertSerializedEquals(map);
+        assertSerializedEquals((GrammaticalTermMapImpl<Noun>)map.makeSkinny());
+        map.put("n1", n1);
+        map.put("n1_a", n1);
+        GrammaticalTermMapImpl<Noun> serialized = getSerialized(map);
+        // same noun should be same in serialized map 
+        assertTrue(serialized.get("n1") == serialized.get("n1_a"));
+    }
 
+    /**
+     * Verify map is same after serialization
+     * @param orig the original map
+     * @throws Exception
+     */
+    private void assertSerializedEquals(GrammaticalTermMapImpl<Noun> orig) throws Exception {
+        GrammaticalTermMapImpl<Noun> serialized = getSerialized(orig);
+        assertEquals("isEmpty returns differently", orig.isEmpty(), serialized.isEmpty());
+        assertEquals("keySet returns different", orig.keySet().size(), serialized.keySet().size());
+
+        for (String key : orig.keySet()) {
+            assertTrue("serialized map doesn't have "+key, serialized.containsKey(key));
+            assertEquals("serialized map have different noun", orig.get(key), serialized.get(key));
+        }
+        assertEquals("The map returns different isSkinny ", orig.isSkinny(), serialized.isSkinny());            
+    }
+
+    /**
+     * Serialize and deserialize a map.
+     * @param input the map to serialize
+     * @return the serialized map
+     * @throws Exception if there's an error
+     */
+    @SuppressWarnings("unchecked")
+    private GrammaticalTermMapImpl<Noun> getSerialized(GrammaticalTermMapImpl<Noun> input) throws Exception{
+        // Serialize
+        byte[] array = null;
+        try ( ByteArrayOutputStream baos = new ByteArrayOutputStream();
+              ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(input);
+            array = baos.toByteArray();
+        } 
+        assertNotNull(array);
+        // Deserialize
+        try ( ByteArrayInputStream bais = new ByteArrayInputStream(array);
+              ObjectInputStream ois = new ObjectInputStream(bais)){
+            return (GrammaticalTermMapImpl<Noun>) ois.readObject();
+        }
+    }
+        
     /**
      * Create a noun for testing
      */

--- a/src/test/java/com/force/i18n/grammar/impl/GrammaticalTermMapImplTest.java
+++ b/src/test/java/com/force/i18n/grammar/impl/GrammaticalTermMapImplTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.force.i18n.grammar.impl;
+
+import java.util.HashSet;
+import java.util.Locale;
+import junit.framework.TestCase;
+import com.force.i18n.*;
+import com.force.i18n.grammar.*;
+import com.force.i18n.grammar.Noun.NounType;
+
+/**
+ * Various sanity test for GrammaticalTermMapImpl
+ * 
+ */
+public class GrammaticalTermMapImplTest extends TestCase {
+    /**
+     * HumanLanguage for testing
+     */
+    private static final HumanLanguage US = LanguageProviderFactory.get().getLanguage(Locale.US);
+
+    /**
+     * Simple get/ put /isEmpty / sets tests
+     * 
+     */
+    public void testSimpleUpdate() throws Exception{
+        GrammaticalTermMapImpl<Noun> map = new GrammaticalTermMapImpl<Noun>();
+        assertTrue(map.isEmpty());
+        Noun n1 = createNoun("n1");
+        Noun n2 = createNoun("n2");
+        map.put("n1", n1);
+        map.put("n2", n2);
+        assertFalse(map.isEmpty());
+        assertEquals(map.get("n1"), n1);
+        assertEquals(map.get("n2"), n2);
+        assertEquals(map.keySet().size(), 2);
+        assertEquals(map.entrySet().size(), 2);
+    }
+
+    /**
+     * Test for writeJson
+     */
+
+    public void testSimpleWriteJson() throws Exception {
+        GrammaticalTermMapImpl<Noun> map = new GrammaticalTermMapImpl<Noun>();
+        StringBuilder sb = new StringBuilder();
+        map.writeJson(sb, null, new LanguageDictionary(US), null);
+        assertEquals(sb.toString(), "{}");
+        sb = new StringBuilder();
+        Noun n1 = createNoun("n1");
+        Noun n2 = createNoun("n2");
+        map.put("n1", n1);
+        map.put("n2", n2);
+
+        map.writeJson(sb, null, new LanguageDictionary(US), null);
+        assertEquals(sb.toString(), "{\"n1\":{\"t\":\"n\",\"l\":\"n1\",\"s\":\"c\",\"v\":{}},\"n2\":{\"t\":\"n\",\"l\":\"n2\",\"s\":\"c\",\"v\":{}}}");
+    }
+
+    /**
+     * Test for makeSkinny
+     */
+    public void testMakeSkinny() {
+        GrammaticalTermMap<Noun> map = new GrammaticalTermMapImpl<Noun>();
+        assertFalse("Initially false", map.isSkinny());
+        Noun n1 = createNoun("n1");
+        map.put("one", n1);
+        map = map.makeSkinny();
+        assertTrue("Now it's true.", map.isSkinny());
+        try {
+            map.put("two", n1);
+            fail("no update allowed on skinny map");
+        } catch (RuntimeException e) {
+            // expected
+        }     
+    }
+
+
+    /**
+     * Create a noun for testing
+     */
+    public Noun createNoun(String some) {
+        LanguageDeclension declension = LanguageDeclensionFactory.get().getDeclension(US);
+        return declension.createNoun(some, some+"alias", NounType.ENTITY, some, LanguageStartsWith.CONSONANT, LanguageGender.NEUTER, "", false, false);
+    }
+}

--- a/src/test/java/com/force/i18n/grammar/impl/LanguageDictionarySerializationTest.java
+++ b/src/test/java/com/force/i18n/grammar/impl/LanguageDictionarySerializationTest.java
@@ -90,7 +90,7 @@ public class LanguageDictionarySerializationTest extends BaseGrammaticalLabelTes
         final String SINGULAR = "account";
         final String PLUARL = "accounts";
 
-        Map<String, Noun> nounMap = getPrivateField(dict, "nounMap");
+        GrammaticalTermMap<Noun> nounMap = dict.getNounMap();
         Multimap<String, Noun> nounsByEntityType = getPrivateField(dict, "nounsByEntityType");
 
         Noun expected = nounMap.get(SINGULAR);
@@ -106,7 +106,7 @@ public class LanguageDictionarySerializationTest extends BaseGrammaticalLabelTes
         assertSame(expected, actual);
 
         if (dict.getDeclension().hasPlural()) {
-            Map<String, Noun> nounMapByPluralAlias = getPrivateField(dict, "nounMapByPluralAlias");
+            GrammaticalTermMap<Noun> nounMapByPluralAlias = dict.getNounByPluralAlias();
             actual = nounMapByPluralAlias.get(PLUARL);
             assertNotNull(actual);
             assertSame(expected, actual);

--- a/src/test/java/com/force/i18n/grammar/parser/GrammaticalLabelLSetLoaderOverrideTest.java
+++ b/src/test/java/com/force/i18n/grammar/parser/GrammaticalLabelLSetLoaderOverrideTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.force.i18n.grammar.parser;
+
+import java.io.IOException;
+import java.util.Locale;
+
+import com.force.i18n.*;
+import com.force.i18n.LanguageLabelSetDescriptor.GrammaticalLabelSetDescriptor;
+import com.force.i18n.grammar.LanguageDictionary;
+import com.force.i18n.grammar.parser.GrammaticalLabelSetLoader;
+
+/**
+ * Test for overriding LabelSetLoader to create another dictionary 
+ * 
+ */
+public class GrammaticalLabelLSetLoaderOverrideTest extends BaseGrammaticalLabelTest{
+
+    public GrammaticalLabelLSetLoaderOverrideTest(String name) {
+        super(name);
+    }
+
+    public static class TestLoader extends GrammaticalLabelSetLoader { 
+        public TestLoader(GrammaticalLabelSetDescriptor dictDesc) {
+            super(dictDesc);
+        }        
+       
+        @Override
+        protected LanguageDictionary createNewDictionary(HumanLanguage language) throws IOException {
+            return new TestInMemoryDic(language);
+        }
+        @Override
+        protected LanguageDictionary finalizeDictionary(LanguageDictionary dictionary) throws IOException {
+            assertTrue(dictionary instanceof TestInMemoryDic);
+            return new TestFinalizedDic(dictionary.getLanguage());        
+        }       
+    }
+
+    public void testOverride() throws Exception {
+        GrammaticalLabelSetLoader loader = new TestLoader(getDescriptor());
+        HumanLanguage ENGLISH_CA = LanguageProviderFactory.get().getLanguage(Locale.CANADA);
+        assertTrue (loader.getSet(ENGLISH_CA).getDictionary() instanceof TestFinalizedDic);
+    }
+
+
+    public static class TestInMemoryDic extends LanguageDictionary {
+        public TestInMemoryDic(HumanLanguage language) {
+            super(language);
+        }
+    }
+    public static class TestFinalizedDic extends LanguageDictionary {
+        public TestFinalizedDic(HumanLanguage language) {
+            super(language);
+        }
+
+    }
+
+}

--- a/src/test/java/com/force/i18n/grammar/parser/GrammaticalLabelLSetLoaderOverrideTest.java
+++ b/src/test/java/com/force/i18n/grammar/parser/GrammaticalLabelLSetLoaderOverrideTest.java
@@ -25,6 +25,9 @@ public class GrammaticalLabelLSetLoaderOverrideTest extends BaseGrammaticalLabel
         super(name);
     }
 
+    /**
+     * Loader for test
+     */
     public static class TestLoader extends GrammaticalLabelSetLoader { 
         public TestLoader(GrammaticalLabelSetDescriptor dictDesc) {
             super(dictDesc);
@@ -40,7 +43,11 @@ public class GrammaticalLabelLSetLoaderOverrideTest extends BaseGrammaticalLabel
             return new TestFinalizedDic(dictionary.getLanguage());        
         }       
     }
-
+    /**
+     * Teset for overriding LabelSetLoader to create another dictionary specified in TestLoader
+     * 
+     * @throws Exception
+     */
     public void testOverride() throws Exception {
         GrammaticalLabelSetLoader loader = new TestLoader(getDescriptor());
         HumanLanguage ENGLISH_CA = LanguageProviderFactory.get().getLanguage(Locale.CANADA);


### PR DESCRIPTION
This is to be able to add some more variation of LanguageDictionary implementation. Currently, it always expects all terms are in-memory and not allowing any changes as it is final class. Create an abstract class GrammaticalTermMap instead of raw Map to enable other implemenation, where can be more memory-efficient.

To create a new implementation extends GrammaticalLabelSetLoader to use new hooks. in it. It can override a new instance or finalized instance after label loading.