### PR TITLE
Perf improvement fixes

### DIFF
--- a/src/main/java/com/force/i18n/commons/util/settings/IniFileUtil.java
+++ b/src/main/java/com/force/i18n/commons/util/settings/IniFileUtil.java
@@ -19,7 +19,7 @@ import com.google.common.collect.Interners;
  */
 public class IniFileUtil {
 	
-	private static final Interner<String> INTERNER = Interners.newWeakInterner();
+	private static final Interner<String> INTERNER = Interners.newBuilder().weak().concurrencyLevel(16).build(); 
 	
     /**
      * For the given {@link String}, return reference to equal String.  Useful for {@link String} deduping.

--- a/src/main/java/com/force/i18n/grammar/GrammaticalTerm.java
+++ b/src/main/java/com/force/i18n/grammar/GrammaticalTerm.java
@@ -13,14 +13,13 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
 
 import com.force.i18n.HumanLanguage;
 import com.force.i18n.LanguageProviderFactory;
 import com.force.i18n.grammar.impl.LanguageDeclensionFactory;
-import com.ibm.icu.impl.locale.XCldrStub.ImmutableMap;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * Represents a grammatical term; generally one that is declined based on a noun form or other
@@ -124,13 +123,13 @@ public abstract class GrammaticalTerm implements Serializable, Comparable<Gramma
 
     private void writeObject(ObjectOutputStream out) throws IOException {
         out.defaultWriteObject();
-        out.writeObject(this.declension.getLanguage().getLocaleString());
+        out.writeInt(this.declension.getLanguage().ordinal());
     }
 
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
         this.name = intern(name);
-        HumanLanguage ul = LanguageProviderFactory.get().getProvider().getLanguage((String)in.readObject());
+        HumanLanguage ul = LanguageProviderFactory.get().getProvider().getAll().get(in.readInt());
         this.declension = LanguageDeclensionFactory.get().getDeclension(ul);
     }
 
@@ -155,12 +154,5 @@ public abstract class GrammaticalTerm implements Serializable, Comparable<Gramma
      */
     protected <T extends GrammaticalForm> Map<T, String> makeSkinny(Map<T, String> map) {
         return ImmutableMap.copyOf(map); 
-    }
-
-    private static class KeyComparator<T extends GrammaticalForm> implements Comparator<T>, Serializable {
-        @Override
-        public int compare(T o1, T o2) {
-            return o1.getKey().compareTo(o2.getKey());
-        }
     }
 }

--- a/src/main/java/com/force/i18n/grammar/GrammaticalTerm.java
+++ b/src/main/java/com/force/i18n/grammar/GrammaticalTerm.java
@@ -9,13 +9,18 @@ package com.force.i18n.grammar;
 
 import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
 
-import java.io.*;
-import java.util.*;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Objects;
 
 import com.force.i18n.HumanLanguage;
 import com.force.i18n.LanguageProviderFactory;
 import com.force.i18n.grammar.impl.LanguageDeclensionFactory;
-import com.google.common.collect.ImmutableSortedMap;
+import com.ibm.icu.impl.locale.XCldrStub.ImmutableMap;
 
 /**
  * Represents a grammatical term; generally one that is declined based on a noun form or other
@@ -138,19 +143,18 @@ public abstract class GrammaticalTerm implements Serializable, Comparable<Gramma
     }
 
     /**
-     * Utility method used to convert static {@link Map}'s concrete type to a {@link ImmutableSortedMap}.
-     * {@link ImmutableSortedMap} have a 8 byte overhead per element and are useful for reducing the per element
-     * overhead, that is traditionally high on most {@code Map} implementations.
+     * Utility method used to convert static {@link Map}'s concrete type to a {@link ImmutableMap}.
+     * This copy could take a lot of cost. Used to use SortedMap but hash is way more cheaper. 
      *
      * @param <T>
      *            the type of the grammatical form for this term
      * @param map
      *            the map to make skinny
-     * @return A {@link ImmutableSortedMap} created from a {@link Map} of {@link GrammaticalForm}'s (key) to
+     * @return A {@link ImmutableMap} created from a {@link Map} of {@link GrammaticalForm}'s (key) to
      *         {@link String}'s (value).
      */
     protected <T extends GrammaticalForm> Map<T, String> makeSkinny(Map<T, String> map) {
-        return ImmutableSortedMap.copyOf(map, new KeyComparator<T>());
+        return ImmutableMap.copyOf(map); 
     }
 
     private static class KeyComparator<T extends GrammaticalForm> implements Comparator<T>, Serializable {

--- a/src/main/java/com/force/i18n/grammar/impl/BengaliDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/BengaliDeclension.java
@@ -9,12 +9,35 @@ package com.force.i18n.grammar.impl;
 
 import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
 
-import java.io.*;
-import java.util.*;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 import com.force.i18n.HumanLanguage;
-import com.force.i18n.grammar.*;
+import com.force.i18n.grammar.Adjective;
+import com.force.i18n.grammar.AdjectiveForm;
+import com.force.i18n.grammar.Article;
+import com.force.i18n.grammar.ArticleForm;
+import com.force.i18n.grammar.ArticledDeclension;
+import com.force.i18n.grammar.LanguageArticle;
+import com.force.i18n.grammar.LanguageCase;
+import com.force.i18n.grammar.LanguageDeclension;
+import com.force.i18n.grammar.LanguageGender;
+import com.force.i18n.grammar.LanguageNumber;
+import com.force.i18n.grammar.LanguagePosition;
+import com.force.i18n.grammar.LanguagePossessive;
+import com.force.i18n.grammar.LanguageStartsWith;
+import com.force.i18n.grammar.Noun;
 import com.force.i18n.grammar.Noun.NounType;
+import com.force.i18n.grammar.NounForm;
 import com.force.i18n.grammar.impl.ComplexGrammaticalForm.ComplexNounForm;
 import com.google.common.collect.ImmutableList;
 
@@ -137,11 +160,6 @@ class BengaliDeclension extends ArticledDeclension {
             return defaultValidate(name, getDeclension().getFieldForms());
         }
 
-        @Override
-        public void makeSkinny() {
-            values = makeSkinny(values);
-        }
-
         /**
          * Need to override so that a cloned BengaliNoun's values map is a HashMap.
          * Else, if you clone() after makeSkinny() has been called, you won't
@@ -163,7 +181,6 @@ class BengaliDeclension extends ArticledDeclension {
         private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
             in.defaultReadObject();
             this.values = ComplexGrammaticalForm.deserializeFormMap(in, getDeclension(), TermType.Noun);
-            makeSkinny();
         }
     }
 

--- a/src/main/java/com/force/i18n/grammar/impl/ComplexGrammaticalForm.java
+++ b/src/main/java/com/force/i18n/grammar/impl/ComplexGrammaticalForm.java
@@ -9,14 +9,36 @@ package com.force.i18n.grammar.impl;
 
 import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
 
-import java.io.*;
-import java.util.*;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import com.force.i18n.HumanLanguage;
 import com.force.i18n.LanguageProviderFactory;
-import com.force.i18n.grammar.*;
+import com.force.i18n.grammar.Adjective;
+import com.force.i18n.grammar.AdjectiveForm;
+import com.force.i18n.grammar.ArticleForm;
+import com.force.i18n.grammar.ArticledDeclension;
 import com.force.i18n.grammar.ArticledDeclension.LegacyArticledNoun;
 import com.force.i18n.grammar.GrammaticalTerm.TermType;
+import com.force.i18n.grammar.LanguageArticle;
+import com.force.i18n.grammar.LanguageCase;
+import com.force.i18n.grammar.LanguageDeclension;
+import com.force.i18n.grammar.LanguageGender;
+import com.force.i18n.grammar.LanguageNumber;
+import com.force.i18n.grammar.LanguagePosition;
+import com.force.i18n.grammar.LanguagePossessive;
+import com.force.i18n.grammar.LanguageStartsWith;
+import com.force.i18n.grammar.ModifierForm;
+import com.force.i18n.grammar.Noun;
+import com.force.i18n.grammar.NounForm;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 
@@ -250,8 +272,8 @@ abstract class ComplexGrammaticalForm implements Serializable, Comparable<Comple
         } else {
             out.writeByte(values.size());
             for (Map.Entry<T,String> entry : values.entrySet()) {
-                out.writeByte(entry.getKey().getOrdinal());
-                out.writeObject(entry.getValue());  // Serialize the "object" because it's been uniquefied
+                out.writeByte(entry.getKey().getOrdinal());                
+                out.writeUTF(entry.getValue());  // Serialize the "object" because it's been uniquefied
             }
         }
     }
@@ -272,7 +294,7 @@ abstract class ComplexGrammaticalForm implements Serializable, Comparable<Comple
         assert formList != null;
         for (int i = 0; i < size; i++) {
             int ordinal = in.readByte();
-            String value = intern((String) in.readObject());
+            String value = intern(in.readUTF());
             result.put(formList.get(ordinal), value);
         }
         return result;

--- a/src/main/java/com/force/i18n/grammar/impl/DravidianDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/DravidianDeclension.java
@@ -285,6 +285,7 @@ abstract class DravidianDeclension extends AbstractLanguageDeclension {
                               LanguageCase.GENITIVE,
                               LanguageCase.ACCUSATIVE,
                               LanguageCase.DATIVE,
+                              LanguageCase.ABLATIVE,  // Ablative & Instrumental merger
                               LanguageCase.LOCATIVE);
         }
 

--- a/src/main/java/com/force/i18n/grammar/impl/DravidianDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/DravidianDeclension.java
@@ -8,12 +8,31 @@ package com.force.i18n.grammar.impl;
 
 import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
 
-import java.io.*;
-import java.util.*;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import com.force.i18n.HumanLanguage;
-import com.force.i18n.grammar.*;
+import com.force.i18n.grammar.AbstractLanguageDeclension;
+import com.force.i18n.grammar.Adjective;
+import com.force.i18n.grammar.AdjectiveForm;
+import com.force.i18n.grammar.LanguageArticle;
+import com.force.i18n.grammar.LanguageCase;
+import com.force.i18n.grammar.LanguageDeclension;
+import com.force.i18n.grammar.LanguageGender;
+import com.force.i18n.grammar.LanguageNumber;
+import com.force.i18n.grammar.LanguagePosition;
+import com.force.i18n.grammar.LanguagePossessive;
+import com.force.i18n.grammar.LanguageStartsWith;
+import com.force.i18n.grammar.Noun;
 import com.force.i18n.grammar.Noun.NounType;
+import com.force.i18n.grammar.NounForm;
 import com.force.i18n.grammar.impl.ComplexGrammaticalForm.ComplexNounForm;
 import com.google.common.collect.ImmutableList;
 
@@ -123,11 +142,6 @@ abstract class DravidianDeclension extends AbstractLanguageDeclension {
             return defaultValidate(name, getDeclension().getFieldForms());
         }
 
-        @Override
-        public void makeSkinny() {
-            values = makeSkinny(values);
-        }
-
         /**
          * Need to override so that a cloned DravidianNoun's values map is a HashMap.
          * Else, if you clone() after makeSkinny() has been called, you won't
@@ -157,7 +171,6 @@ abstract class DravidianDeclension extends AbstractLanguageDeclension {
             in.defaultReadObject();
 
             this.values = ComplexGrammaticalForm.deserializeFormMap(in, getDeclension(), TermType.Noun);
-            makeSkinny();
         }
     }
 
@@ -272,7 +285,6 @@ abstract class DravidianDeclension extends AbstractLanguageDeclension {
                               LanguageCase.GENITIVE,
                               LanguageCase.ACCUSATIVE,
                               LanguageCase.DATIVE,
-                              LanguageCase.ABLATIVE,  // Ablative & Instrumental merger
                               LanguageCase.LOCATIVE);
         }
 

--- a/src/main/java/com/force/i18n/grammar/impl/GermanicDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/GermanicDeclension.java
@@ -9,16 +9,47 @@ package com.force.i18n.grammar.impl;
 
 import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
 
-import java.io.*;
-import java.util.*;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.logging.Logger;
 
 import com.force.i18n.HumanLanguage;
 import com.force.i18n.commons.text.CaseFolder;
-import com.force.i18n.grammar.*;
+import com.force.i18n.grammar.Adjective;
+import com.force.i18n.grammar.AdjectiveForm;
+import com.force.i18n.grammar.Article;
+import com.force.i18n.grammar.ArticleForm;
+import com.force.i18n.grammar.ArticledDeclension;
+import com.force.i18n.grammar.LanguageArticle;
+import com.force.i18n.grammar.LanguageCase;
+import com.force.i18n.grammar.LanguageDeclension;
+import com.force.i18n.grammar.LanguageGender;
+import com.force.i18n.grammar.LanguageNumber;
+import com.force.i18n.grammar.LanguagePosition;
+import com.force.i18n.grammar.LanguagePossessive;
+import com.force.i18n.grammar.LanguageStartsWith;
+import com.force.i18n.grammar.Noun;
 import com.force.i18n.grammar.Noun.NounType;
-import com.force.i18n.grammar.impl.ComplexGrammaticalForm.*;
-import com.google.common.collect.*;
+import com.force.i18n.grammar.NounForm;
+import com.force.i18n.grammar.impl.ComplexGrammaticalForm.ComplexAdjective;
+import com.force.i18n.grammar.impl.ComplexGrammaticalForm.ComplexAdjectiveForm;
+import com.force.i18n.grammar.impl.ComplexGrammaticalForm.ComplexArticleForm;
+import com.force.i18n.grammar.impl.ComplexGrammaticalForm.ComplexArticledNoun;
+import com.force.i18n.grammar.impl.ComplexGrammaticalForm.ComplexNounForm;
+import com.force.i18n.grammar.impl.ComplexGrammaticalForm.ModifierFormMap;
+import com.force.i18n.grammar.impl.ComplexGrammaticalForm.NounFormMap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * Provide a declension system for a germanic language.  Generally, there are
@@ -341,12 +372,6 @@ abstract class GermanicDeclension extends ArticledDeclension {
             in.defaultReadObject();
 
             this.values = ComplexGrammaticalForm.deserializeFormMap(in, getDeclension(), TermType.Article);
-            makeSkinny();
-        }
-
-        @Override
-        public void makeSkinny() {
-            values = makeSkinny(values);
         }
     }
 

--- a/src/main/java/com/force/i18n/grammar/parser/TermAttributes.java
+++ b/src/main/java/com/force/i18n/grammar/parser/TermAttributes.java
@@ -7,13 +7,28 @@
 
 package com.force.i18n.grammar.parser;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 
 import org.xml.sax.Attributes;
 
 import com.force.i18n.HumanLanguage;
 import com.force.i18n.LanguageProviderFactory;
-import com.force.i18n.grammar.*;
+import com.force.i18n.grammar.AdjectiveForm;
+import com.force.i18n.grammar.ArticleForm;
+import com.force.i18n.grammar.GrammaticalTerm;
+import com.force.i18n.grammar.LanguageArticle;
+import com.force.i18n.grammar.LanguageCase;
+import com.force.i18n.grammar.LanguageDeclension;
+import com.force.i18n.grammar.LanguageGender;
+import com.force.i18n.grammar.LanguageNumber;
+import com.force.i18n.grammar.LanguagePosition;
+import com.force.i18n.grammar.LanguagePossessive;
+import com.force.i18n.grammar.LanguageStartsWith;
+import com.force.i18n.grammar.Noun;
+import com.force.i18n.grammar.NounForm;
 import com.force.i18n.grammar.impl.LanguageDeclensionFactory;
 
 /**
@@ -282,12 +297,12 @@ public final class TermAttributes implements Serializable {
 
     private void writeObject(ObjectOutputStream out) throws IOException {
         out.defaultWriteObject();
-        out.writeObject(this.declension.getLanguage().getLocaleString());
+        out.writeInt(this.declension.getLanguage().ordinal());
     }
 
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
-        HumanLanguage ul = LanguageProviderFactory.get().getProvider().getLanguage((String)in.readObject());
+        HumanLanguage ul = LanguageProviderFactory.get().getProvider().getAll().get(in.readInt());
         this.declension = LanguageDeclensionFactory.get().getDeclension(ul);
     }
 }

--- a/src/main/java/com/force/i18n/grammar/parser/TermRefTag.java
+++ b/src/main/java/com/force/i18n/grammar/parser/TermRefTag.java
@@ -10,9 +10,12 @@ package com.force.i18n.grammar.parser;
 import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
-import com.force.i18n.grammar.*;
+import com.force.i18n.grammar.GrammaticalForm;
+import com.force.i18n.grammar.GrammaticalTerm;
 import com.force.i18n.grammar.GrammaticalTerm.TermType;
 import com.force.i18n.grammar.LanguageDictionary;
 
@@ -129,13 +132,13 @@ public abstract class TermRefTag extends RefTag {
     private void writeObject(java.io.ObjectOutputStream s) throws IOException {
         // Write out the threshold, loadfactor, and any hidden stuff
         s.defaultWriteObject();
-        s.writeObject(this.name);
+        s.writeUTF(this.name);
     }
 
     private void readObject(java.io.ObjectInputStream s) throws IOException, ClassNotFoundException {
         // Read in the threshold, loadfactor, and any hidden stuff
         s.defaultReadObject();
-        this.name = intern((String)s.readObject());
+        this.name = intern(s.readUTF());
     }
 
     protected Object readResolve() {


### PR DESCRIPTION
- Increase concurrency of String Interner.
- GrammaticalTerm#makeSkinny now uses ImmutableMap. SortedMap could be better in terms of memory usage, but generation cost was too high
- use read/writeUTF for string output in ComplexGrammaticalForm