### PR TITLE
Fix npe running LanguageDictionary#writeJson

### DIFF
--- a/src/main/java/com/force/i18n/grammar/LanguageDictionary.java
+++ b/src/main/java/com/force/i18n/grammar/LanguageDictionary.java
@@ -669,7 +669,9 @@ public class LanguageDictionary implements Serializable {
      * @throws IOException if an error happens during append
      */
     public void writeJsonTerms(Appendable out, boolean useRenamedNouns, Collection<GrammaticalTerm> terms) throws IOException {
-        Collection<String> termsToInclude = terms.stream().map((t)->t.getName()).collect(Collectors.toSet());
+        Collection<String> termsToInclude = 
+                terms == null ? null : 
+                terms.stream().map((t)->t.getName()).collect(Collectors.toSet());
         writeJson(out, useRenamedNouns, termsToInclude);
     }
     

--- a/src/test/java/com/force/i18n/grammar/offline/OfflineProcessingTest.java
+++ b/src/test/java/com/force/i18n/grammar/offline/OfflineProcessingTest.java
@@ -6,7 +6,10 @@
  */
 package com.force.i18n.grammar.offline;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.script.ScriptEngine;
@@ -17,9 +20,18 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
-import com.force.i18n.*;
+import com.force.i18n.HumanLanguage;
+import com.force.i18n.LabelRef;
+import com.force.i18n.LabelReference;
 import com.force.i18n.LanguageLabelSetDescriptor.GrammaticalLabelSetDescriptor;
-import com.force.i18n.grammar.*;
+import com.force.i18n.LanguageProviderFactory;
+import com.force.i18n.Renameable;
+import com.force.i18n.grammar.GrammaticalLabelSet;
+import com.force.i18n.grammar.GrammaticalTerm;
+import com.force.i18n.grammar.LanguageDictionary;
+import com.force.i18n.grammar.Noun;
+import com.force.i18n.grammar.RenamingProvider;
+import com.force.i18n.grammar.RenamingProviderFactory;
 import com.force.i18n.grammar.parser.BaseGrammaticalLabelTest;
 import com.force.i18n.grammar.parser.BaseGrammaticalLabelTest.MockRenamingProvider;
 import com.force.i18n.grammar.parser.GrammaticalLabelSetLoader;
@@ -56,10 +68,13 @@ public class OfflineProcessingTest {
         set.writeJson(sb, Collections.singleton("Sample.click_here_to_create_new_account"), termsInUse);
         sb.append(";\nvar terms=");
         dict.writeJson(sb, false, termsInUse.stream().map(a->a.getName()).collect(Collectors.toList()));
-
         ScriptEngine engine = JsTestUtils.getScriptEngine();
         engine.eval(sb.toString());
-	}
+        
+        // make sure dict will run with null terms. tests for contents TBD
+        dict.writeJson(new StringBuilder(), false, null);
+	}	
+	
 	
 	@Test 
 	public void compareRenameable() throws Exception {

--- a/src/test/java/com/force/i18n/grammar/offline/OfflineProcessingTest.java
+++ b/src/test/java/com/force/i18n/grammar/offline/OfflineProcessingTest.java
@@ -6,10 +6,7 @@
  */
 package com.force.i18n.grammar.offline;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import javax.script.ScriptEngine;
@@ -20,18 +17,10 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
-import com.force.i18n.HumanLanguage;
-import com.force.i18n.LabelRef;
-import com.force.i18n.LabelReference;
+import com.force.i18n.*;
 import com.force.i18n.LanguageLabelSetDescriptor.GrammaticalLabelSetDescriptor;
-import com.force.i18n.LanguageProviderFactory;
 import com.force.i18n.Renameable;
-import com.force.i18n.grammar.GrammaticalLabelSet;
-import com.force.i18n.grammar.GrammaticalTerm;
-import com.force.i18n.grammar.LanguageDictionary;
-import com.force.i18n.grammar.Noun;
-import com.force.i18n.grammar.RenamingProvider;
-import com.force.i18n.grammar.RenamingProviderFactory;
+import com.force.i18n.grammar.*;
 import com.force.i18n.grammar.parser.BaseGrammaticalLabelTest;
 import com.force.i18n.grammar.parser.BaseGrammaticalLabelTest.MockRenamingProvider;
 import com.force.i18n.grammar.parser.GrammaticalLabelSetLoader;


### PR DESCRIPTION
Throws NPE with null termsToInclude.(this should retrieve everything)

GrammaticalTermMapImpl support this null , but converion logic in LanguageDictionary didn't check this case.