### PR TITLE
Use ImmutableSortedMap for better memory consumption

### DIFF
--- a/src/main/java/com/force/i18n/grammar/impl/GrammaticalTermMapImpl.java
+++ b/src/main/java/com/force/i18n/grammar/impl/GrammaticalTermMapImpl.java
@@ -1,56 +1,45 @@
 package com.force.i18n.grammar.impl;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.Serializable;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
+
+import java.io.*;
+import java.util.*;
 
 import com.force.i18n.HumanLanguage;
 import com.force.i18n.commons.util.collection.MapSerializer;
-import com.force.i18n.grammar.GrammaticalTerm;
-import com.force.i18n.grammar.GrammaticalTermMap;
-import com.force.i18n.grammar.LanguageDictionary;
-import com.force.i18n.grammar.Noun;
-import com.force.i18n.grammar.RenamingProvider;
-import com.google.common.collect.ImmutableMap;
-
-import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
+import com.force.i18n.grammar.*;
+import com.google.common.collect.ImmutableSortedMap;
 
 /**
  * In-memory version of GrammaticalTermMap
  *
  * @author ytanida
  */
-public class GrammaticalTermMapImpl<T extends GrammaticalTerm> implements GrammaticalTermMap<T>, Serializable {
+public class GrammaticalTermMapImpl<T extends GrammaticalTerm> implements GrammaticalTermMap<T> {
     private static final long serialVersionUID = 2099717329853215271L;
 
     protected transient Map<String, T> map;
     private boolean isSkinny = false;
 
     public GrammaticalTermMapImpl() {
-        map = new HashMap<>();        
+        map = new HashMap<>();
     }
 
     public GrammaticalTermMapImpl(Map<String, T> map, boolean isSkinny) {
         this.isSkinny = isSkinny;
-        if (isSkinny)
-            this.map = new ImmutableMap.Builder<String, T>().putAll(map).build();
-        else
+        if (isSkinny) {
+            // this uses "natural ordering" built-in comparator that ends up calling GrammaticalTerm.compareTo()
+            // maybe better to specify comparator for just comparing GrammaticalTerm.getName() here
+            this.map = ImmutableSortedMap.copyOf(map);
+        } else {
             this.map = map;
-
+        }
     }
 
     @Override
     public boolean equals(Object obj) {
-        if(obj == this) 
-            return true;
-        if(!(obj instanceof GrammaticalTermMapImpl)) 
-            return false;
+        if (obj == this) return true;
+        if (!(obj instanceof GrammaticalTermMapImpl)) return false;
 
         @SuppressWarnings("unchecked")
         GrammaticalTermMapImpl<T> other = (GrammaticalTermMapImpl<T>)obj;
@@ -73,14 +62,15 @@ public class GrammaticalTermMapImpl<T extends GrammaticalTerm> implements Gramma
     }
 
     @Override
-    public void writeJson(Appendable out, RenamingProvider renamingProvider, LanguageDictionary dictionary, Collection<String> termsToInclude) throws IOException {
+    public void writeJson(Appendable out, RenamingProvider renamingProvider, LanguageDictionary dictionary,
+            Collection<String> termsToInclude) throws IOException {
         Set<String> wrote = new HashSet<>();
         out.append('{');
         if (termsToInclude != null) {
             boolean first = true;
             for (String name : termsToInclude) {
                 GrammaticalTerm term = map.get(name);
-                if(term != null) {
+                if (term != null) {
                     if (term instanceof Noun) term = dictionary.getNounOverride((Noun)term);
                     if (!first) {
                         out.append(',');
@@ -97,7 +87,7 @@ public class GrammaticalTermMapImpl<T extends GrammaticalTerm> implements Gramma
         }
         out.append('}');
     }
-    
+
     private void writeJson(Appendable out, RenamingProvider renamingProvider, HumanLanguage lang) throws IOException {
         boolean first = true;
         for (GrammaticalTerm term : map.values()) {
@@ -109,8 +99,9 @@ public class GrammaticalTermMapImpl<T extends GrammaticalTerm> implements Gramma
             writeJsonTerm(out, renamingProvider, term, lang);
         }
     }
-    
-    private void writeJsonTerm(Appendable out, RenamingProvider renamingProvider, GrammaticalTerm term, HumanLanguage lang) throws IOException {
+
+    private void writeJsonTerm(Appendable out, RenamingProvider renamingProvider, GrammaticalTerm term,
+            HumanLanguage lang) throws IOException {
         if (renamingProvider != null && term instanceof Noun && renamingProvider.useRenamedNouns()) {
             Noun renamedNoun = renamingProvider.getRenamedNoun(lang, ((Noun)term).getName());
             if (renamedNoun != null) term = renamedNoun;
@@ -129,7 +120,6 @@ public class GrammaticalTermMapImpl<T extends GrammaticalTerm> implements Gramma
         return map.get(name);
     }
 
-
     @Override
     public boolean containsKey(String name) {
         return map.containsKey(name);
@@ -147,19 +137,16 @@ public class GrammaticalTermMapImpl<T extends GrammaticalTerm> implements Gramma
 
     @Override
     public void put(String k, T v) {
-        if(isSkinny)
-            throw new IllegalStateException("This map is not able to modify");
-        map.put(k,v);
+        if (isSkinny) throw new IllegalStateException("This map is not able to modify");
+        map.put(k, v);
     }
-    
-    @SuppressWarnings("unchecked")
-    @Override 
+
+    @Override
     public void putAll(GrammaticalTermMap<T> other) {
-        if(isSkinny)
-            throw new IllegalStateException("This map is not able to modify");
+        if (isSkinny) throw new IllegalStateException("This map is not able to modify");
         map.putAll(((GrammaticalTermMapImpl<T>)other).map);
     }
-    
+
     @Override
     public boolean isEmpty() {
         return map.isEmpty();
@@ -167,6 +154,7 @@ public class GrammaticalTermMapImpl<T extends GrammaticalTerm> implements Gramma
 
     /**
      * Override default serializer to avoid any duplicated in the serialized map.
+     *
      * @param in
      * @throws IOException
      */
@@ -178,6 +166,7 @@ public class GrammaticalTermMapImpl<T extends GrammaticalTerm> implements Gramma
 
     /**
      * Override default serializer to avoid any duplicated in the serialized map.
+     *
      * @param in
      * @throws IOException
      */


### PR DESCRIPTION
`GrammaticalTermMapImpl` uses Guava's [`ImmutableMap.Builder()`](https://javadoc.io/doc/com.google.guava/guava/32.0.0-jre/com/google/common/collect/ImmutableMap.Builder.html) to make it "skinny".  Replace it with [`ImmutableSortedMap`](https://javadoc.io/doc/com.google.guava/guava/32.0.0-jre/com/google/common/collect/ImmutableSortedMap.html) that shows much better memory consumption.   Although it takes longer to re-construct map,  this is more suitable for the purpose -- make "skinny" map