### PR TITLE
Including keyword token in the list of sensitive keywords

### DIFF
--- a/src/main/java/com/force/i18n/commons/util/settings/SettingsUtil.java
+++ b/src/main/java/com/force/i18n/commons/util/settings/SettingsUtil.java
@@ -18,7 +18,7 @@ public class SettingsUtil {
     /**
      * Section keys that correspond to sensitive data which should be redacted in config.jsp
      */
-    static final String[] SENSITIVE_KEYWORDS = {"password", "secret", "key", "authenticationid", "certificates" };
+    static final String[] SENSITIVE_KEYWORDS = {"password", "secret", "key", "authenticationid", "certificates", "token" };
 
     /**
      * @return true if the value is sensitive and should be censored, false otherwise.

--- a/src/test/java/com/force/i18n/commons/util/settings/SettingsUtilTest.java
+++ b/src/test/java/com/force/i18n/commons/util/settings/SettingsUtilTest.java
@@ -33,7 +33,11 @@ public class SettingsUtilTest extends TestCase {
         assertTrue("Expected keyword secret to be considered sensitive",SettingsUtil.isSensitive(SECTION_NAME, "DomainSecret"));
         assertTrue("Expected keyword key to be considered sensitive",SettingsUtil.isSensitive(SECTION_NAME, "DomainKey"));
         assertTrue("Expected keyword authenticationid to be considered sensitive",SettingsUtil.isSensitive(SECTION_NAME, "authenticationid"));
+        assertTrue("Expected keyword token to be considered sensitive", SettingsUtil.isSensitive(SECTION_NAME, "token"));
+        assertTrue("Expected keyword token to be considered sensitive", SettingsUtil.isSensitive(SECTION_NAME, "AccessToken"));
+        assertTrue("Expected keyword token to be considered sensitive", SettingsUtil.isSensitive(SECTION_NAME, "DomainAccounttoken"));
 
         assertFalse("Testing a non-sensitive word",SettingsUtil.isSensitive(SECTION_NAME, "Parameter"));
+        assertFalse("Testing a non-sensitive word",SettingsUtil.isSensitive(SECTION_NAME, "StatusTokeep"));
     }
 }


### PR DESCRIPTION
Code from here, but resubmitted as this commit is not signed.

https://github.com/salesforce/grammaticus/commit/9613038a53f2e1f8ad4865972c7d1eed1be14c08