### PR TITLE
Replace Guava LoadingCache with Caffeine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <icu4j.version>69.1</icu4j.version>
     <icu4j-localespi.version>69.1</icu4j-localespi.version>
     <picocli.version>4.1.4</picocli.version>
+    <caffeine.version>2.8.0</caffeine.version>
   </properties>
 
   <profiles>
@@ -298,6 +299,16 @@
       <optional>true</optional>
     </dependency>
 
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+      <version>${caffeine.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>guava</artifactId>
+      <version>${caffeine.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.freemarker</groupId>

--- a/src/main/java/com/force/i18n/DefaultLanguagePluralRulesImpl.java
+++ b/src/main/java/com/force/i18n/DefaultLanguagePluralRulesImpl.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2019, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 package com.force.i18n;
@@ -9,63 +9,67 @@ package com.force.i18n;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.guava.CaffeinatedGuava;
 import com.google.common.cache.*;
 import com.ibm.icu.text.PluralRules;
 import com.ibm.icu.text.PluralRules.PluralType;
 
 /**
  * Default implementation of LanguagePluralRules that uses ICU4J.
- * 
+ *
  * @author stamm
  * @since 1.1
  */
 class DefaultLanguagePluralRulesImpl implements LanguagePluralRules {
-	private final HumanLanguage language;
-	private final PluralRules cardinal;
-	private final PluralRules ordinal;
-	public DefaultLanguagePluralRulesImpl(HumanLanguage language) {
-		this.language = language;
-		this.cardinal = PluralRules.forLocale(language.getLocale(), PluralType.CARDINAL);
-		this.ordinal = PluralRules.forLocale(language.getLocale(), PluralType.ORDINAL);
-	}
+    private final HumanLanguage language;
+    private final PluralRules cardinal;
+    private final PluralRules ordinal;
 
-	@Override
-	public HumanLanguage getHumanLanguage() {
-		return this.language;
-	}
+    public DefaultLanguagePluralRulesImpl(HumanLanguage language) {
+        this.language = language;
+        this.cardinal = PluralRules.forLocale(language.getLocale(), PluralType.CARDINAL);
+        this.ordinal = PluralRules.forLocale(language.getLocale(), PluralType.ORDINAL);
+    }
 
-	private PluralRules getPluralRules(NumberType numberType) {
-		return numberType == NumberType.ORDINAL ? this.ordinal : this.cardinal;
-	}
-	
-	// Convert from ICU4j to Grammaticus category
-	private PluralCategory fromString(String string) {
-		switch (string) {
-		case PluralRules.KEYWORD_ZERO: return PluralCategory.ZERO;
-		case PluralRules.KEYWORD_ONE: return PluralCategory.ONE;
-		case PluralRules.KEYWORD_TWO: return PluralCategory.TWO;
-		case PluralRules.KEYWORD_FEW: return PluralCategory.FEW;
-		case PluralRules.KEYWORD_MANY: return PluralCategory.MANY;
-		case PluralRules.KEYWORD_OTHER: return PluralCategory.OTHER;
-		}
-		return PluralCategory.OTHER;
-	}
-	
-	@Override
-	public PluralCategory getPluralCategory(Number value, NumberType numberType) {
-		return fromString(getPluralRules(numberType).select(value != null ? value.doubleValue() : 0));
-	}
+    @Override
+    public HumanLanguage getHumanLanguage() {
+        return this.language;
+    }
 
-	@Override
-	public Set<PluralCategory> getSupportedCategories(NumberType numberType) {
-		return getPluralRules(numberType).getKeywords().stream().map(a->fromString(a)).collect(Collectors.toSet());
-	}
-	
-	static LanguagePluralRules forLanguage(HumanLanguage language) {
-		return RULES_CACHE.getUnchecked(language);
-	}
+    private PluralRules getPluralRules(NumberType numberType) {
+        return numberType == NumberType.ORDINAL ? this.ordinal : this.cardinal;
+    }
 
-	// Have a default cache so we don't load it all the time for every language
-	private static LoadingCache<HumanLanguage, LanguagePluralRules> RULES_CACHE = 
-			CacheBuilder.newBuilder().concurrencyLevel(1).build(CacheLoader.from((l)->new DefaultLanguagePluralRulesImpl(l)));
+    // Convert from ICU4j to Grammaticus category
+    private PluralCategory fromString(String string) {
+        switch (string) {
+        case PluralRules.KEYWORD_ZERO: return PluralCategory.ZERO;
+        case PluralRules.KEYWORD_ONE: return PluralCategory.ONE;
+        case PluralRules.KEYWORD_TWO: return PluralCategory.TWO;
+        case PluralRules.KEYWORD_FEW: return PluralCategory.FEW;
+        case PluralRules.KEYWORD_MANY: return PluralCategory.MANY;
+        case PluralRules.KEYWORD_OTHER: return PluralCategory.OTHER;
+        default:
+            return PluralCategory.OTHER;
+        }
+    }
+
+    @Override
+    public PluralCategory getPluralCategory(Number value, NumberType numberType) {
+        return fromString(getPluralRules(numberType).select(value != null ? value.doubleValue() : 0));
+    }
+
+    @Override
+    public Set<PluralCategory> getSupportedCategories(NumberType numberType) {
+        return getPluralRules(numberType).getKeywords().stream().map(a -> fromString(a)).collect(Collectors.toSet());
+    }
+
+    static LanguagePluralRules forLanguage(HumanLanguage language) {
+        return RULES_CACHE.getUnchecked(language);
+    }
+
+    // Have a default cache so we don't load it all the time for every language
+    private static final LoadingCache<HumanLanguage, LanguagePluralRules> RULES_CACHE =
+            CaffeinatedGuava.build(Caffeine.newBuilder(), CacheLoader.from(DefaultLanguagePluralRulesImpl::new));
 }

--- a/src/test/java/com/force/i18n/grammar/parser/GrammaticalLabelTest.java
+++ b/src/test/java/com/force/i18n/grammar/parser/GrammaticalLabelTest.java
@@ -543,6 +543,7 @@ public class GrammaticalLabelTest extends BaseGrammaticalLabelTest {
         HumanLanguage ENGLISH_GB = LanguageProviderFactory.get().getLanguage(LanguageConstants.ENGLISH_GB);
         HumanLanguage ENGLISH_AU = LanguageProviderFactory.get().getLanguage(LanguageConstants.ENGLISH_AU);
         HumanLanguage FRENCH = LanguageProviderFactory.get().getLanguage(LanguageConstants.FRENCH);
+        HumanLanguage GERMAN = LanguageProviderFactory.get().getLanguage(LanguageConstants.GERMAN);
 
         GrammaticalLabelSetDescriptor desc = getDescriptor();
 
@@ -552,6 +553,7 @@ public class GrammaticalLabelTest extends BaseGrammaticalLabelTest {
 
         GrammaticalLabelSetLoader loader = new GrammaticalLabelSetLoader(config);
         loader.getSet(ENGLISH);
+
         Thread.sleep(1);
         assertNull(loader.getCache().getIfPresent(desc));
 
@@ -575,8 +577,13 @@ public class GrammaticalLabelTest extends BaseGrammaticalLabelTest {
         assertNotNull(loader.getCache().getIfPresent(desc.getForOtherLanguage(ENGLISH_GB)));
         assertNotNull(loader.getCache().getIfPresent(desc.getForOtherLanguage(ENGLISH_AU)));
 
+        // Caffeine does not evict prior the threadshold, but after the size crossed
         loader.getSet(FRENCH);
-        assertEquals(3, loader.getCache().size());
+        assertEquals(4, loader.getCache().size());
         assertNotNull(loader.getCache().getIfPresent(desc.getForOtherLanguage(FRENCH)));
+
+        loader.getSet(GERMAN);
+        assertEquals(4, loader.getCache().size());
+        assertNotNull(loader.getCache().getIfPresent(desc.getForOtherLanguage(GERMAN)));
     }
 }


### PR DESCRIPTION
Replace Guava dependency with [Caffeine](https://github.com/ben-manes/caffeine)

Subclass of `GrammaticalLabelSetLoader` should aware of method signature change from:
  ```
  protected CacheBuilder<Object, Object> getCacheBuilder(LabelSetLoaderConfig config)
  ```
  to:
  ```
  protected Caffeine<Object, Object> getCacheBuilder(LabelSetLoaderConfig config)
  ```
