### PR TITLE
Configurable cache with Caffeine or Guava

### DIFF
--- a/src/main/java/com/force/i18n/grammar/parser/LabelSetLoaderConfig.java
+++ b/src/main/java/com/force/i18n/grammar/parser/LabelSetLoaderConfig.java
@@ -23,6 +23,7 @@ public class LabelSetLoaderConfig {
     public static final String RECORD_STATS = "loader.cache.stats";
     public static final String LOADER_EXPIRE_AFTER = "loader.cache.expireAfter";
     public static final String LOADER_MAX_SIZE = "loader.cache.maxSize";
+    public static final String USE_CAFFEINE = "loader.cache.useCaffeine";
 
     private final GrammaticalLabelSetDescriptor desc;
     private final GrammaticalLabelSetProvider parent;
@@ -33,6 +34,7 @@ public class LabelSetLoaderConfig {
     private boolean isCacheStatsEnabled;
     private Duration cacheExpireAfter; // expiration in minues
     private long cacheMaxSize; // max allowed entires
+    private boolean useCaffeine;
 
     public LabelSetLoaderConfig(GrammaticalLabelSetDescriptor baseDesc, GrammaticalLabelSetProvider parent) {
         this.desc = baseDesc;
@@ -45,6 +47,7 @@ public class LabelSetLoaderConfig {
         setCacheStatsEnabled(BasePropertyFile.stringToBoolean(getProperty(RECORD_STATS)));
         setCacheExpireAfter(Duration.ofMinutes(getPropertyLong(LOADER_EXPIRE_AFTER)));
         setCacheMaxSize(getPropertyLong(LOADER_MAX_SIZE));
+        setCaffeine(BasePropertyFile.stringToBoolean(getProperty(USE_CAFFEINE)));
     }
 
     public LabelSetLoaderConfig(LabelSetLoaderConfig copyFrom) {
@@ -56,6 +59,7 @@ public class LabelSetLoaderConfig {
         setCacheStatsEnabled(copyFrom.isCacheStatsEnabled());
         setCacheExpireAfter(copyFrom.getCacheExpireAfter());
         setCacheMaxSize(copyFrom.getCacheMaxSize());
+        setCaffeine(copyFrom.useCaffeine());
     }
 
     public static String getProperty(String prop) {
@@ -136,13 +140,23 @@ public class LabelSetLoaderConfig {
         return this;
     }
 
+    public LabelSetLoaderConfig setCaffeine(boolean useCaffeine) {
+        this.useCaffeine = useCaffeine;
+        return this;
+    }
+
+    public boolean useCaffeine() {
+        return this.useCaffeine;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("stats=").append(this.isCacheStatsEnabled)
                 .append(", expire=").append(this.cacheExpireAfter)
                 .append(", size=").append(this.cacheMaxSize)
-                .append(", dir=").append(this.cacheDir.toAbsolutePath());
+                .append(", dir=").append(this.cacheDir.toAbsolutePath())
+                .append(", useCaffeine=").append(this.useCaffeine);
         return sb.toString();
     }
 }

--- a/src/main/java/com/force/i18n/grammaticus.properties
+++ b/src/main/java/com/force/i18n/grammaticus.properties
@@ -52,3 +52,6 @@ loader.cache.expireAfter=0
 
 # maximum size of cache entry. This cache key is LabelSetDescriptor(language). no limit for 0.
 loader.cache.maxSize=0
+
+# use Caffeine as internal cache otherwise, Guava LoadingCache will be used.
+loader.cache.useCaffeine=true


### PR DESCRIPTION
Minor fix for #366 that entirely migrated to Caffeine. 
Make `GrammaticalLabelSetLoader` configurable to switch between Guava or Caffeine for internal caching.

