### PR TITLE
Fix declensions returning null for singular form

### DIFF
--- a/src/main/java/com/force/i18n/commons/util/LogUtil.java
+++ b/src/main/java/com/force/i18n/commons/util/LogUtil.java
@@ -1,0 +1,39 @@
+package com.force.i18n.commons.util;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.force.i18n.HumanLanguage;
+import com.force.i18n.grammar.LanguageDeclension;
+
+public final class LogUtil {
+    public static final String PREFIX = "###\t";
+    public static final String PREFIX_ERROR = PREFIX + "Error: ";
+    public static final String PREFIX_WARN = PREFIX + "Warning: ";
+    public static final String PREFIX_ERROR_WITH_DECLENSION = PREFIX_ERROR + "%s: ";
+    public static final String PREFIX_WARN_WITH_DECLENSION = PREFIX_WARN + "%s: ";
+
+    private LogUtil() {
+        // do not consturct
+    }
+
+    public static void log(Logger logger, Level level, String msg, Object... params) {
+        logger.log(level, () -> (params == null || params.length == 0) ? msg : String.format(msg, params));
+    }
+
+    public static void log(Logger logger, Level level, String prefix, HumanLanguage language, String msg,
+            Object... params) {
+        logger.log(level, () -> String.format(prefix, language.getLocaleString())
+                + ((params == null || params.length == 0) ? msg : String.format(msg, params)));
+    }
+
+    // log with Declension to print language as prefix
+    public static void error(Logger logger, Level level, LanguageDeclension declension, String msg, Object... params) {
+        log(logger, level, PREFIX_ERROR_WITH_DECLENSION, declension.getLanguage(), msg, params);
+    }
+
+    public static void warning(Logger logger, Level level, LanguageDeclension declension, String msg,
+            Object... params) {
+        log(logger, level, PREFIX_WARN_WITH_DECLENSION, declension.getLanguage(), msg, params);
+    }
+}

--- a/src/main/java/com/force/i18n/grammar/AbstractLanguageDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/AbstractLanguageDeclension.java
@@ -7,12 +7,15 @@
 
 package com.force.i18n.grammar;
 
+import static com.force.i18n.commons.util.LogUtil.error;
+import static com.force.i18n.commons.util.LogUtil.warning;
 import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
 
-import java.io.*;
+import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.force.i18n.*;
@@ -510,7 +513,7 @@ public abstract class AbstractLanguageDeclension implements LanguageDeclension {
         @Override
         public boolean validate(String name) {
             if (this.value == null) {
-                logger.info("###\tError: The adjective " + name + " has no value");
+                error(logger, Level.INFO, this.getDeclension(), "The adjective \"%s\" has no value", name);
                 return false;
             }
             return true;
@@ -583,7 +586,7 @@ public abstract class AbstractLanguageDeclension implements LanguageDeclension {
         @Override
         protected boolean validateGender(String name) {
             if (getGender() != LanguageGender.NEUTER) {
-                logger.info(VALIDATION_WARNING_HEADER + name + " must be neuter");
+                warning(logger, Level.INFO, getDeclension(), "\"%s\" must be neuter", name);
             }
             return super.validateGender(name);  // Let it go
         }
@@ -631,14 +634,12 @@ public abstract class AbstractLanguageDeclension implements LanguageDeclension {
             value = intern(value);
             if (form.getNumber().isPlural()) {
                 this.plural = value;
-                if (value != null && value.equals(this.singular))
-                 {
+                if (value != null && value.equals(this.singular)) {
                     this.singular = value; // Keep one reference for serialization
                 }
             } else {
                 this.singular = value;
-                if (value != null && value.equals(this.plural))
-                 {
+                if (value != null && value.equals(this.plural)) {
                     this.plural = value; // Keep one reference for serialization
                 }
             }
@@ -647,7 +648,7 @@ public abstract class AbstractLanguageDeclension implements LanguageDeclension {
         @Override
         protected boolean validateValues(String name, LanguageCase _case) {
             if (this.singular == null) {
-                logger.info("###\tError: The noun " + name + " has no singular form for: "  + getDeclension().getLanguage());
+                error(logger, Level.INFO, this.getDeclension(), "The noun \"%s\" has no singular form", name);
                 return false;
             }
             return true;

--- a/src/main/java/com/force/i18n/grammar/Article.java
+++ b/src/main/java/com/force/i18n/grammar/Article.java
@@ -7,11 +7,13 @@
 
 package com.force.i18n.grammar;
 
+import static com.force.i18n.commons.util.LogUtil.error;
 import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
 
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.google.common.collect.ImmutableSet;
@@ -106,7 +108,8 @@ public abstract class Article extends NounModifier {
         for (ArticleForm form : getDeclension().getArticleForms()) {
             if (getString(form) == null) {
                 if (requiredForms.contains(form)) {
-                    logger.fine("###\tError: The article " + name + " is missing required " + form + " form");
+                    error(logger, Level.FINE, this.getDeclension(), "The article \"%s\" is missing required %s form ",
+                            name, form);
                     // TODO: Uncomment the return false below once we actually handle validation
                     // Presently, the return value is simply ignored
                     // return false;
@@ -144,10 +147,12 @@ public abstract class Article extends NounModifier {
                     // so default to the absolute default value
                     s = getDefaultValue();
                     if (s == null) {
-                        logger.info("###\tError: The article " + name + " has no " + form + " form and no default could be found");
+                        error(logger, Level.INFO, this.getDeclension(),
+                                "The article \"%s\" has no %s form and no default could be found", name, form);
                         return false;
                     } else {
-                        logger.info("###\tERROR: The article " + name + " has no obvious default for " + form + "form");
+                        error(logger, Level.INFO, this.getDeclension(), "The article \"%s\" no obvious default for %s form",
+                                name, form);
                     }
                 }
 

--- a/src/main/java/com/force/i18n/grammar/Noun.java
+++ b/src/main/java/com/force/i18n/grammar/Noun.java
@@ -7,6 +7,7 @@
 
 package com.force.i18n.grammar;
 
+import static com.force.i18n.commons.util.LogUtil.error;
 import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
 
 import java.io.IOException;
@@ -220,10 +221,6 @@ public abstract class Noun extends GrammaticalTerm implements Cloneable {
         return  genderVal && valuesVal;
     }
 
-    // used only by validation
-    protected static final String VALIDATION_ERROR_HEADER = "###\tError:";
-    protected static final String VALIDATION_WARNING_HEADER = "###\tWarning:";
-
     // deep clone
     @Override
     public Noun clone() {
@@ -277,7 +274,8 @@ public abstract class Noun extends GrammaticalTerm implements Cloneable {
         } else {
             // 99% of the time this is because of the horribleness that was articles in french and italian.
             if (logger.isLoggable(Level.FINER)) {
-                logger.finer("###\tError: The noun " + getName() + " has no exact form in " + declension.getLanguage() + " for " + number +":"+_case+":"+poss+":" + art);
+                error(logger, Level.FINER, declension, "The noun \"%s\" has no exact form for %s:%s:%s:%s", getName(),
+                        number, _case, poss, art);
             }
         }
     }
@@ -291,13 +289,14 @@ public abstract class Noun extends GrammaticalTerm implements Cloneable {
                     String value = getCloseButNoCigarString(form);
 
                     if (value == null) {
-                        logger.info("###\tError: The noun " + name + " has no " + form + " form and no default could be found");
+                        error(logger, Level.INFO, this.getDeclension(),
+                                "The noun \"%s\" has no %s form and no default could be found", name, form);
                         return false;
                     }
                     setString(intern(value), form);
                 } else if (requiredForms.contains(form)) {
                     // TODO SLT: This logic seems faulty.  Why'd we bother
-                    logger.finest("###\tError: The noun " + name + " has no " + form + " form");
+                    error(logger, Level.FINEST, this.getDeclension(), "The noun \"%s\" has no %s form", name, form);
                     return false;
                 }
             }

--- a/src/main/java/com/force/i18n/grammar/impl/AmharicDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/AmharicDeclension.java
@@ -7,9 +7,11 @@
 
 package com.force.i18n.grammar.impl;
 
+import static com.force.i18n.commons.util.LogUtil.error;
 import static com.force.i18n.grammar.LanguageCase.*;
 
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.force.i18n.HumanLanguage;
@@ -197,17 +199,17 @@ class AmharicDeclension extends SemiticDeclension {
                 String value = getExactString(form);
                 if (value == null) {
                     if (getNounType() == NounType.ENTITY) {
-                    	// Only do the "defaulting" on entities because the "entity"
-                    	// value in sfdcnames.xml usually only specifies 2 forms
-                    	String val = getCloseButNoCigarString(form);
-                    	if (val == null) {
-                    		logger.info("###\tError: The noun " + name + " has no " + form
-                    					+ " form and no default could be found");
-                    		return false;
+                        // Only do the "defaulting" on entities because the "entity"
+                        // value in sfdcnames.xml usually only specifies 2 forms
+                        String val = getCloseButNoCigarString(form);
+                        if (val == null) {
+                            error(logger, Level.INFO, this.getDeclension(),
+                                    "The noun \"%s\" has no %s form and no default could be found", name, form);
+                            return false;
                         }
                     } else if (requiredForms.contains(form)) {
                         // TODO SLT: This logic seems faulty.  Why'd we bother
-                        logger.finest("###\tError: The noun " + name + " has no " + form + " form");
+                        error(logger, Level.FINEST, this.getDeclension(), "The noun \"%s\" has no %s form", name, form);
                         return false;
                     }
                 }
@@ -274,7 +276,7 @@ class AmharicDeclension extends SemiticDeclension {
         return ALLOWED_CASES;
     }
 
-	@Override
+    @Override
     public boolean hasPossessive() {
         return true;
     }
@@ -304,15 +306,14 @@ class AmharicDeclension extends SemiticDeclension {
         return nounForms;
     }
 
-	@Override
-	protected String getDefiniteArticlePrefix(LanguageStartsWith startsWith) {
-		// Amharic, unlike the related Tigrinya (እታ), doesn't have a definite article prefix,
-		// but it has a suffix which changes the last character of the word or adds one depending on
-		// gender and case.
-		// A boy (ልጅ).  The boy (ልጁ).
-		// A dog (ውሻ).  The dog (ውሻው).
-		// When full support is required
-		return "";
-	}
-
+    @Override
+    protected String getDefiniteArticlePrefix(LanguageStartsWith startsWith) {
+        // Amharic, unlike the related Tigrinya (እታ), doesn't have a definite article prefix,
+        // but it has a suffix which changes the last character of the word or adds one depending on
+        // gender and case.
+        // A boy (ልጅ). The boy (ልጁ).
+        // A dog (ውሻ). The dog (ውሻው).
+        // When full support is required
+        return "";
+    }
 }

--- a/src/main/java/com/force/i18n/grammar/impl/ArabicDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/ArabicDeclension.java
@@ -7,10 +7,12 @@
 
 package com.force.i18n.grammar.impl;
 
+import static com.force.i18n.commons.util.LogUtil.error;
 import static com.force.i18n.grammar.LanguageCase.ACCUSATIVE;
 import static com.force.i18n.grammar.LanguageCase.NOMINATIVE;
 
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.force.i18n.HumanLanguage;
@@ -45,7 +47,7 @@ class ArabicDeclension extends SemiticDeclension {
     private static final String FINAL_ALIF = "\u0627";  // ا   What is added to indefinite nouns
 
     public ArabicDeclension(HumanLanguage language) {
-    	super(language);
+        super(language);
         assert language.getLocale().getLanguage().equals("ar") : "Initializing a variant Arabic declension for non-arabic";
 
         // Generate the different forms from subclass methods
@@ -251,21 +253,21 @@ class ArabicDeclension extends SemiticDeclension {
                             // value in sfdcnames.xml usually only specifies 2 forms
                             String val = getCloseButNoCigarString(form);
                             if (val == null) {
-                                logger.info("###\tError: The noun " + name + " has no " + form
-                                        + " form and no default could be found");
+                                error(logger, Level.INFO, this.getDeclension(),
+                                        "The noun \"%s\" has no %s form and no default could be found", name, form);
                                 return false;
                             }
                             setString(val, form);
                         }
                     } else if (form.getNumber() == LanguageNumber.DUAL) {
-                    	// Default dual to plural
+                        // Default dual to plural
                         String val = getCloseButNoCigarString(form);
                         if (val != null) {
                             setString(val, form);
                         }
                     } else if (requiredForms.contains(form)) {
                         // TODO SLT: This logic seems faulty.  Why'd we bother
-                        logger.finest("###\tError: The noun " + name + " has no " + form + " form");
+                        error(logger, Level.FINEST, this.getDeclension(), "The noun \"%s\" has no %s form", name, form);
                         return false;
                     }
                 }
@@ -280,7 +282,7 @@ class ArabicDeclension extends SemiticDeclension {
     protected static class ArabicAdjective extends ComplexAdjective<ArabicAdjectiveForm> {
         private static final long serialVersionUID = 1L;
 
-		// The "keys" here are StartsWith, Gender, and Plurality
+        // The "keys" here are StartsWith, Gender, and Plurality
         ArabicAdjective(LanguageDeclension declension, String name, LanguagePosition position) {
             super(declension, name, position);
         }
@@ -356,11 +358,12 @@ class ArabicDeclension extends SemiticDeclension {
     }
 
     @Override
-	public Set<LanguageNumber> getAllowedNumbers() {
-    	return LanguageNumber.DUAL_SET;  // Written arabic has a compulsory dual form. Will default to normal plural form when needed.
-	}
+    public Set<LanguageNumber> getAllowedNumbers() {
+        // Written arabic has a compulsory dual form. Will default to normal plural form when needed.
+        return LanguageNumber.DUAL_SET;
+    }
 
-	@Override
+    @Override
     public boolean hasPossessive() {
         return true;
     }

--- a/src/main/java/com/force/i18n/grammar/impl/ArmenianDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/ArmenianDeclension.java
@@ -7,9 +7,11 @@
 
 package com.force.i18n.grammar.impl;
 
+import static com.force.i18n.commons.util.LogUtil.warning;
 import static com.force.i18n.grammar.LanguageCase.*;
 
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.force.i18n.HumanLanguage;
@@ -61,7 +63,7 @@ class ArmenianDeclension extends AbstractLanguageDeclension {
 
 
     public ArmenianDeclension(HumanLanguage language) {
-    	super(language);
+        super(language);
 
         // Generate the different forms from subclass methods
         ImmutableList.Builder<ArmenianNounForm> entityBuilder = ImmutableList.builder();
@@ -144,7 +146,7 @@ class ArmenianDeclension extends AbstractLanguageDeclension {
 
         @Override
         protected final Class<ArmenianNounForm> getFormClass() {
-        	return ArmenianNounForm.class;
+            return ArmenianNounForm.class;
         }
 
         @Override
@@ -155,7 +157,7 @@ class ArmenianDeclension extends AbstractLanguageDeclension {
         @Override
         protected boolean validateGender(String name) {
             if (getGender() != LanguageGender.NEUTER)
-                logger.info(VALIDATION_WARNING_HEADER + name + " must be neuter");
+                warning(logger, Level.INFO, getDeclension(), "\"%s\" must be neuter", name);
             return super.validateGender(name);  // Let it go
         }
     }

--- a/src/main/java/com/force/i18n/grammar/impl/BulgarianDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/BulgarianDeclension.java
@@ -7,10 +7,12 @@
 
 package com.force.i18n.grammar.impl;
 
+import static com.force.i18n.commons.util.LogUtil.error;
 import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.force.i18n.HumanLanguage;
@@ -248,7 +250,7 @@ class BulgarianDeclension extends AbstractLanguageDeclension {
         @Override
         protected boolean validateValues(String name, LanguageCase _case) {
             if (this.singular == null) {
-                logger.info("###\tError: The noun " + name + " has no singular form");
+                error(logger, Level.INFO, this.getDeclension(), "The noun \"%s\" has no singular form", name);
                 return false;
             }
             return true;

--- a/src/main/java/com/force/i18n/grammar/impl/EnglishDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/EnglishDeclension.java
@@ -7,10 +7,12 @@
 
 package com.force.i18n.grammar.impl;
 
+import static com.force.i18n.commons.util.LogUtil.error;
 import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.force.i18n.HumanLanguage;
@@ -25,12 +27,12 @@ import com.google.common.collect.ImmutableList;
  * @author stamm
  */
 class EnglishDeclension extends ArticledDeclension {
-	private static final Logger logger = Logger.getLogger(EnglishDeclension.class.getName());
+    private static final Logger logger = Logger.getLogger(EnglishDeclension.class.getName());
 
-	public EnglishDeclension(HumanLanguage language) {
-		super(language);
+    public EnglishDeclension(HumanLanguage language) {
+        super(language);
         assert language.getLocale().getLanguage().equals("en") : "Initializing a language that isn't english";
-	}
+    }
 
     /**
      * The english articles are distinguished by whether the next noun starts with a vowel
@@ -59,17 +61,18 @@ class EnglishDeclension extends ArticledDeclension {
                     (form.getStartsWith() == LanguageStartsWith.VOWEL ? SINGULAR_V : SINGULAR)
                     : PLURAL;
         }
-		@Override
-		public String getKey() {
-			return getNumber().getDbValue() + "-" + getStartsWith().getDbValue();
-		}
 
-		@Override
-		public void appendJsFormReplacement(Appendable a, String termFormVar, String genderVar, String startsWithVar)
-				throws IOException {
-			// The only variant is in the signular, so we don't want to screw up "the"
-			a.append(termFormVar+".charAt(0)=='"+LanguageNumber.PLURAL.getDbValue()+"'?"+termFormVar+":'"+LanguageNumber.SINGULAR.getDbValue()+"-'+"+startsWithVar);
-		}
+        @Override
+        public String getKey() {
+            return getNumber().getDbValue() + "-" + getStartsWith().getDbValue();
+        }
+
+        @Override
+        public void appendJsFormReplacement(Appendable a, String termFormVar, String genderVar, String startsWithVar)
+                throws IOException {
+            // The only variant is in the signular, so we don't want to screw up "the"
+            a.append(termFormVar+".charAt(0)=='"+LanguageNumber.PLURAL.getDbValue()+"'?"+termFormVar+":'"+LanguageNumber.SINGULAR.getDbValue()+"-'+"+startsWithVar);
+        }
     }
 
     /**
@@ -116,7 +119,7 @@ class EnglishDeclension extends ArticledDeclension {
         @Override
         public boolean validate(String name) {
             if (this.singular == null) {
-                logger.info("###\tError: The article " + name + " has no form");
+                error(logger, Level.INFO, this.getDeclension(), "The article \"%s\" has no form", name);
                 return false;
             }
             if (this.singularVowel == null) {

--- a/src/main/java/com/force/i18n/grammar/impl/FinnishDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/FinnishDeclension.java
@@ -7,10 +7,12 @@
 
 package com.force.i18n.grammar.impl;
 
+import static com.force.i18n.commons.util.LogUtil.warning;
 import static com.force.i18n.grammar.LanguageCase.*;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.force.i18n.HumanLanguage;
@@ -60,7 +62,7 @@ class FinnishDeclension extends AbstractLanguageDeclension {
     }
 
     public FinnishDeclension(HumanLanguage language) {
-    	super(language);
+        super(language);
         // Generate the different forms from subclass methods
         ImmutableList.Builder<FinnishNounForm> entityBuilder = ImmutableList.builder();
         ImmutableList.Builder<FinnishNounForm> fieldBuilder = ImmutableList.builder();
@@ -212,7 +214,7 @@ class FinnishDeclension extends AbstractLanguageDeclension {
         @Override
         protected boolean validateGender(String name) {
             if (getGender() != LanguageGender.NEUTER) {
-                logger.info(VALIDATION_WARNING_HEADER + name + " invalid gender");
+                warning(logger, Level.INFO, getDeclension(), "\"%s\" invalid gender", name);
                 setGender(getDeclension().getDefaultGender());
             }
             return true;
@@ -231,7 +233,7 @@ class FinnishDeclension extends AbstractLanguageDeclension {
 
         @Override
         protected final Class<FinnishAdjectiveForm> getFormClass() {
-        	return FinnishAdjectiveForm.class;
+            return FinnishAdjectiveForm.class;
         }
 
         @Override
@@ -281,10 +283,10 @@ class FinnishDeclension extends AbstractLanguageDeclension {
 
     static class EstonianDeclension extends FinnishDeclension{
         public EstonianDeclension(HumanLanguage language) {
-			super(language);
-		}
+            super(language);
+        }
 
-		@Override
+        @Override
         public EnumSet<LanguagePossessive> getRequiredPossessive() {
             return EnumSet.of(LanguagePossessive.NONE);
         }

--- a/src/main/java/com/force/i18n/grammar/impl/GermanicDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/GermanicDeclension.java
@@ -7,6 +7,7 @@
 
 package com.force.i18n.grammar.impl;
 
+import static com.force.i18n.commons.util.LogUtil.warning;
 import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
 
 import java.io.IOException;
@@ -20,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.force.i18n.HumanLanguage;
@@ -294,7 +296,7 @@ abstract class GermanicDeclension extends ArticledDeclension {
         @Override
         protected boolean validateGender(String name) {
             if (!getDeclension().getRequiredGenders().contains(getGender())) {
-                logger.info(VALIDATION_WARNING_HEADER + name + " invalid gender");
+                warning(logger, Level.INFO, getDeclension(), "\"%s\" invalid gender", name);
                 setGender(getDeclension().getDefaultGender());
             }
             return true;

--- a/src/main/java/com/force/i18n/grammar/impl/HebrewDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/HebrewDeclension.java
@@ -7,10 +7,12 @@
 
 package com.force.i18n.grammar.impl;
 
+import static com.force.i18n.commons.util.LogUtil.error;
 import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.force.i18n.HumanLanguage;
@@ -34,7 +36,7 @@ class HebrewDeclension extends SemiticDeclension {
 
     private static final Logger logger = Logger.getLogger(HebrewDeclension.class.getName());
 
-    public static enum HebrewNounForm implements NounForm {
+    public enum HebrewNounForm implements NounForm {
         SINGULAR(LanguageNumber.SINGULAR, LanguageArticle.ZERO),
         PLURAL(LanguageNumber.PLURAL, LanguageArticle.ZERO),
         SINGULAR_DEF(LanguageNumber.SINGULAR, LanguageArticle.DEFINITE),
@@ -61,7 +63,7 @@ class HebrewDeclension extends SemiticDeclension {
     /**
      * Adjective form for languages that don't care about "starts with"
      */
-    public static enum HebrewModifierForm implements AdjectiveForm {
+    public enum HebrewModifierForm implements AdjectiveForm {
         SINGULAR_MASCULINE(LanguageNumber.SINGULAR, LanguageGender.MASCULINE),
         SINGULAR_FEMININE(LanguageNumber.SINGULAR, LanguageGender.FEMININE),
         PLURAL_MASCULINE(LanguageNumber.PLURAL, LanguageGender.MASCULINE),
@@ -130,8 +132,11 @@ class HebrewDeclension extends SemiticDeclension {
         @Override
         public String getExactString(NounForm form) {
             assert form instanceof HebrewNounForm : "It's not kosher to pass in a non-hebrew noun " + form;
-            return form.getArticle() == LanguageArticle.DEFINITE ? form.getNumber() == LanguageNumber.PLURAL ? plural_def : singular_def
-                    : form.getNumber() == LanguageNumber.PLURAL ? plural : singular;
+            if (form.getArticle() == LanguageArticle.DEFINITE) {
+                return form.getNumber() == LanguageNumber.PLURAL ? plural_def : singular_def;
+            } else {
+                return form.getNumber() == LanguageNumber.PLURAL ? plural : singular;
+            }
         }
 
         @Override
@@ -154,7 +159,7 @@ class HebrewDeclension extends SemiticDeclension {
         @Override
         protected boolean validateValues(String name, LanguageCase _case) {
             if (this.singular == null) {
-                logger.info("###\tError: The noun " + name + " has no singular form");
+                error(logger, Level.INFO, this.getDeclension(), "The noun \"%s\" has no singular form", name);
                 return false;
             }
             // Default the values for entity nouns, but not for others to make rename fields more specific.

--- a/src/main/java/com/force/i18n/grammar/impl/HungarianDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/HungarianDeclension.java
@@ -7,11 +7,13 @@
 
 package com.force.i18n.grammar.impl;
 
+import static com.force.i18n.commons.util.LogUtil.warning;
 import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
 import static com.force.i18n.grammar.LanguageCase.*;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.force.i18n.HumanLanguage;
@@ -163,8 +165,8 @@ class HungarianDeclension extends ArticledDeclension {
         @Override public LanguageNumber getNumber() { return this.number; }
         @Override public LanguageStartsWith getStartsWith() {return this.startsWith; }
         static HungarianArticleForm getForm(ModifierForm form) {
-            return form.getNumber() == LanguageNumber.SINGULAR ?
-                    (form.getStartsWith() == LanguageStartsWith.VOWEL ? SINGULAR_V : SINGULAR)
+            return form.getNumber() == LanguageNumber.SINGULAR
+                    ? (form.getStartsWith() == LanguageStartsWith.VOWEL ? SINGULAR_V : SINGULAR)
                     : (form.getStartsWith() == LanguageStartsWith.VOWEL ? PLURAL_V : PLURAL);
         }
 
@@ -205,7 +207,7 @@ class HungarianDeclension extends ArticledDeclension {
         @Override
         protected boolean validateGender(String name) {
             if (getGender() != LanguageGender.NEUTER)
-                logger.info(VALIDATION_WARNING_HEADER + name + " must be neuter");
+                warning(logger, Level.INFO, getDeclension(), "\"%s\" must be neuter", name);
             return super.validateGender(name);  // Let it go
         }
     }

--- a/src/main/java/com/force/i18n/grammar/impl/IndoAryanDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/IndoAryanDeclension.java
@@ -6,7 +6,10 @@
  */
 package com.force.i18n.grammar.impl;
 
+import static com.force.i18n.commons.util.LogUtil.warning;
+
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.force.i18n.HumanLanguage;
@@ -180,7 +183,7 @@ abstract class IndoAryanDeclension extends AbstractLanguageDeclension {
         @Override
         protected boolean validateGender(String name) {
             if (!getDeclension().getRequiredGenders().contains(getGender())) {
-                logger.info(VALIDATION_WARNING_HEADER + name + " invalid gender");
+                warning(logger, Level.INFO, getDeclension(), "\"%s\" invalid gender", name);
                 setGender(getDeclension().getDefaultGender());
             }
             return true;

--- a/src/main/java/com/force/i18n/grammar/impl/KoreanDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/KoreanDeclension.java
@@ -6,10 +6,12 @@
  */
 package com.force.i18n.grammar.impl;
 
+import static com.force.i18n.commons.util.LogUtil.error;
 import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.force.i18n.HumanLanguage;
@@ -123,7 +125,7 @@ public class KoreanDeclension extends AbstractLanguageDeclension implements With
         @Override
         public boolean validate(String name) {
             if (this.prevEndsWithConsonant == null) {
-                logger.info("###\tError: The adjective " + name + " has no form");
+                error(logger, Level.INFO, this.getDeclension(), "The adjective \"%s\" has no form", name);
                 return false;
             }
             if (this.prevEndsWithVowel == null) {
@@ -205,7 +207,7 @@ public class KoreanDeclension extends AbstractLanguageDeclension implements With
         @Override
         protected boolean validateValues(String name, LanguageCase _case) {
             if (this.value == null) {
-                logger.info("###\tError: The noun " + name + " has no value");
+                error(logger, Level.INFO, this.getDeclension(), "The noun \"%s\" has no value", name);
                 return false;
             }
             return true;

--- a/src/main/java/com/force/i18n/grammar/impl/RomanceDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/RomanceDeclension.java
@@ -81,7 +81,7 @@ abstract class RomanceDeclension extends ArticledDeclension {
                 //$$$ this is right, but temporary disabled because we always load English data
                 //    first and that data may contain neuter. That displays huge warning
                 //    message which is pretty annoying.
-                //                logger.info(VALIDATION_WARNING_HEADER + name + " neuter is not expected");
+                //          LogUtil.warning(logger, Level.INFO, getDeclension(), "\"%s\" neuter is not expected", name);
                 setGender(getDeclension().getDefaultGender());
             }
             return true; // accept any gender
@@ -301,8 +301,8 @@ abstract class RomanceDeclension extends ArticledDeclension {
 
     static class SpanishDeclension extends RomanceDeclension {
         public SpanishDeclension(HumanLanguage language) {
-    		super(language);
-    	}
+            super(language);
+        }
 
         private static final EnumMap<RomanceModifierForm, String> INDEFINITE_ARTICLE =
             new EnumMap<>(ImmutableMap.of(
@@ -339,7 +339,7 @@ abstract class RomanceDeclension extends ArticledDeclension {
 
     static class PortugueseDeclension extends RomanceDeclension {
         public PortugueseDeclension(HumanLanguage language) {
-        	super(language);
+            super(language);
             assert language.getLocale().getLanguage().equals("pt") : "Initializing a variant portuguese declension for non-portuguese";
         }
 

--- a/src/main/java/com/force/i18n/grammar/impl/RomanianDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/RomanianDeclension.java
@@ -7,10 +7,12 @@
 
 package com.force.i18n.grammar.impl;
 
+import static com.force.i18n.commons.util.LogUtil.error;
 import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.force.i18n.HumanLanguage;
@@ -47,7 +49,7 @@ class RomanianDeclension extends RomanceDeclension {
 
 
     public RomanianDeclension(HumanLanguage language) {
-    	super(language);
+        super(language);
         // Generate the different forms from subclass methods
         ImmutableList.Builder<RomanianNounForm> entityBuilder = ImmutableList.builder();
         ImmutableList.Builder<RomanianNounForm> fieldBuilder = ImmutableList.builder();
@@ -173,17 +175,16 @@ class RomanianDeclension extends RomanceDeclension {
         @Override
         protected boolean validateValues(String name, LanguageCase _case) {
             for (NounForm form : getDeclension().getAllNounForms()) {
-                if (getString(form) == null) {
-                    // Only do the "defaulting" on entities
-                    if (getNounType() == NounType.ENTITY) {
-                        String value = getCloseButNoCigarString(form);
+                // Only do the "defaulting" on entities
+                if (getString(form) == null && getNounType() == NounType.ENTITY) {
+                    String value = getCloseButNoCigarString(form);
 
-                        if (value == null) {
-                            logger.info("###\tError: The noun " + name + " has no " + form + " form and no default could be found");
-                            return false;
-                        }
-                        setString(value, form);
+                    if (value == null) {
+                        error(logger, Level.INFO, this.getDeclension(),
+                                "The noun \"%s\" has no %s form and no default could be found", name, form);
+                        return false;
                     }
+                    setString(value, form);
                 }
             }
             return true;

--- a/src/main/java/com/force/i18n/grammar/impl/SimpleDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/SimpleDeclension.java
@@ -7,10 +7,12 @@
 
 package com.force.i18n.grammar.impl;
 
+import static com.force.i18n.commons.util.LogUtil.error;
 import static com.force.i18n.commons.util.settings.IniFileUtil.intern;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.force.i18n.HumanLanguage;
@@ -30,7 +32,7 @@ class SimpleDeclension extends AbstractLanguageDeclension {
     private static final Logger logger = Logger.getLogger(SimpleDeclension.class.getName());
 
     public SimpleDeclension(HumanLanguage language) {
-    	super(language);
+        super(language);
     }
 
     // Nice classes that can be reused for languages with little or no inflection
@@ -87,14 +89,14 @@ class SimpleDeclension extends AbstractLanguageDeclension {
         }
 
         @Override
-        protected boolean validateValues(String name, LanguageCase _case) {
-///CLOVER:OFF
+        protected boolean validateValues(String name, LanguageCase languageCase) {
+/// CLOVER:OFF
             if (this.value == null) {
-                // this is wrong.  the noun should have singular form
-                logger.severe("###\tError: The noun " + name + " has no value");
+                // this is wrong. the noun should have singular form
+                error(logger, Level.SEVERE, this.getDeclension(), "The noun \"%s\" has no value", name);
                 return false;
             }
-///CLOVER:ON
+/// CLOVER:ON
             return true;
         }
 
@@ -410,7 +412,7 @@ class SimpleDeclension extends AbstractLanguageDeclension {
         @Override
         protected boolean validateValues(String name, LanguageCase _case) {
             if (this.value == null) {
-                logger.info("###\tError: The noun " + name + " has no singular form");
+                error(logger, Level.INFO, this.getDeclension(), "The noun \"%s\" has no singular form", name);
                 return false;
             }
             return true;

--- a/src/main/java/com/force/i18n/grammar/impl/SlavicDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/SlavicDeclension.java
@@ -7,11 +7,13 @@
 
 package com.force.i18n.grammar.impl;
 
+import static com.force.i18n.commons.util.LogUtil.warning;
 import static com.force.i18n.grammar.LanguageCase.*;
 import static com.force.i18n.grammar.LanguageGender.*;
 import static com.force.i18n.grammar.LanguageNumber.SINGULAR;
 
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.force.i18n.HumanLanguage;
@@ -35,7 +37,7 @@ abstract class SlavicDeclension extends AbstractLanguageDeclension {
     private final ModifierFormMap<SlavicAdjectiveForm> adjectiveFormMap;
 
     protected SlavicDeclension(HumanLanguage language) {
-    	super(language);
+        super(language);
         // Generate the different forms from subclass methods
         ImmutableList.Builder<SlavicNounForm> nounBuilder = ImmutableList.builder();
         ImmutableMultimap.Builder<LanguageCase, SlavicNounForm> byCaseBuilder = ImmutableMultimap.builder();
@@ -185,7 +187,7 @@ abstract class SlavicDeclension extends AbstractLanguageDeclension {
         @Override
         protected boolean validateGender(String name) {
             if (getDeclension().hasGender() && !getDeclension().getRequiredGenders().contains(getGender())) {
-                logger.info(VALIDATION_WARNING_HEADER + name + " invalid gender");
+                warning(logger, Level.INFO, getDeclension(), "\"%s\" invalid gender", name);
                 setGender(getDeclension().getDefaultGender());
             }
             return true;
@@ -442,7 +444,7 @@ abstract class SlavicDeclension extends AbstractLanguageDeclension {
      */
     static class VariantSerboCroatianDeclension extends SlavicDeclension {
         public VariantSerboCroatianDeclension(HumanLanguage language) {
-        	super(language);
+            super(language);
         }
 
         @Override

--- a/src/main/java/com/force/i18n/grammar/impl/TurkicDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/TurkicDeclension.java
@@ -7,9 +7,11 @@
 
 package com.force.i18n.grammar.impl;
 
+import static com.force.i18n.commons.util.LogUtil.warning;
 import static com.force.i18n.grammar.LanguageCase.*;
 
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.force.i18n.HumanLanguage;
@@ -58,8 +60,8 @@ abstract class TurkicDeclension extends ArticledDeclension {
         return true;
     }
 
-    public TurkicDeclension(HumanLanguage language) {
-    	super(language);
+    protected TurkicDeclension(HumanLanguage language) {
+        super(language);
         // Generate the different forms from subclass methods
         ImmutableList.Builder<TurkishNounForm> entityBuilder = ImmutableList.builder();
         ImmutableList.Builder<TurkishNounForm> fieldBuilder = ImmutableList.builder();
@@ -133,18 +135,18 @@ abstract class TurkicDeclension extends ArticledDeclension {
      * See TurkishNounForm for more info
      */
     public static class TurkishNoun extends ComplexArticledNoun<TurkishNounForm> {
-		private static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
 
         TurkishNoun(TurkicDeclension declension, String name, String pluralAlias, NounType type, String entityName, LanguageStartsWith startsWith, String access, boolean isStandardField, boolean isCopiedFromDefault) {
             super(declension, name, pluralAlias, type, entityName, startsWith, LanguageGender.NEUTER, access, isStandardField, isCopiedFromDefault);
         }
 
         @Override
-		protected final Class<TurkishNounForm> getFormClass() {
-        	return TurkishNounForm.class;
-		}
+        protected final Class<TurkishNounForm> getFormClass() {
+            return TurkishNounForm.class;
+        }
 
-		@Override
+        @Override
         protected boolean validateValues(String name, LanguageCase _case) {
             return defaultValidate(name, getDeclension().getFieldForms());
         }
@@ -152,7 +154,7 @@ abstract class TurkicDeclension extends ArticledDeclension {
         @Override
         protected boolean validateGender(String name) {
             if (getGender() != LanguageGender.NEUTER)
-                logger.info(VALIDATION_WARNING_HEADER + name + " must be neuter");
+                warning(logger, Level.INFO, getDeclension(), "\"%s\" must be neuter", name);
             return super.validateGender(name);  // Let it go
         }
 

--- a/src/main/java/com/force/i18n/grammar/parser/GrammaticalLabelFileParser.java
+++ b/src/main/java/com/force/i18n/grammar/parser/GrammaticalLabelFileParser.java
@@ -15,6 +15,7 @@ import java.net.URLConnection;
 import java.text.MessageFormat;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.xml.parsers.*;
@@ -25,6 +26,7 @@ import org.xml.sax.SAXException;
 import com.force.i18n.*;
 import com.force.i18n.commons.text.GenericUniquefy;
 import com.force.i18n.commons.text.Uniquefy;
+import com.force.i18n.commons.util.LogUtil;
 import com.force.i18n.grammar.*;
 import com.force.i18n.settings.*;
 import com.force.i18n.settings.BasePropertyFile.MetaDataInfo;
@@ -236,8 +238,6 @@ public class GrammaticalLabelFileParser implements BasePropertyFile.Parser {
     // ====================================================================
     // Param alias handler: <param name="nnn" alias="xxx"/>
     // ====================================================================
-    private static final String BAD_ALIAS = "###\tBad alias: ";
-
     class AliasParam implements Comparable<AliasParam> {
         final URL file;
         final int lineNumber;
@@ -276,16 +276,17 @@ public class GrammaticalLabelFileParser implements BasePropertyFile.Parser {
             if (file != null) {
                 fileMsg = this.file.getPath() + "(" + lineNumber + "): ";
             }
-            String message = BAD_ALIAS + fileMsg + msg + (key == null ? "" : key);
+            String message = fileMsg + msg + (key == null ? "" : key);
             // if we are loading English labels in dev-mode throw an exception here
             if (I18nJavaUtil.isDebugging() && LanguageProviderFactory.get().getBaseLanguage() == GrammaticalLabelFileParser.this.getDictionary().getLanguage()
                     && !(GrammaticalLabelFileParser.this.desc instanceof TestLanguageLabelSetDescriptor)) {
                 throw new IllegalStateException(message);
             } else {
-                if (illegalAliases == null) illegalAliases = new ArrayList<AliasParam>(10);
+                if (illegalAliases == null) illegalAliases = new ArrayList<>(10);
                 illegalAliases.add(this);
                 // Oh, just keep going
-                logger.fine(message);
+                LogUtil.log(logger, Level.FINE, LogUtil.PREFIX, getDictionary().getLanguage(), "Bad alias: %s: %s",
+                        message);
             }
         }
 


### PR DESCRIPTION
- If `RomanceNoun` (used by French) has no singular form, Haitian declension derives no value and ends up returning `null`
  See fix in: 
  - src/main/java/com/force/i18n/grammar/Adjective.java
  - src/main/java/com/force/i18n/grammar/ArticledDeclension.java

- Refactor logging to normalize format/methods (through `LogUtil`).  All error logs shows language 