### PR TITLE
fix severe error for Haitian-Creole declension

### DIFF
--- a/src/main/java/com/force/i18n/grammar/ArticledDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/ArticledDeclension.java
@@ -134,7 +134,8 @@ public abstract class ArticledDeclension extends AbstractLanguageDeclension {
         @Override
         public boolean validate(String name) {
             if (this.value == null) {
-                logger.info("###\tError: The article " + name + " has no form");
+                HumanLanguage language = this.getDeclension().getLanguage();
+                logger.info(() -> "###\tError: " + language + "The article " + name + " has no form");
                 return false;
             }
             return true;
@@ -168,7 +169,10 @@ public abstract class ArticledDeclension extends AbstractLanguageDeclension {
 
         @Override
         public String getDefaultString(boolean isPlural) {
-            return isPlural && plural != null ? plural : singular;
+            if (isPlural && plural != null) return plural;
+
+            // there's a corner case that dictionary has only plural form. try to return non-null
+            return singular != null ? singular : plural;
         }
 
         @Override
@@ -187,14 +191,12 @@ public abstract class ArticledDeclension extends AbstractLanguageDeclension {
             value = intern(value);
             if (form.getNumber().isPlural()) {
                 this.plural = value;
-                if (value != null && value.equals(this.singular))
-                 {
+                if (value != null && value.equals(this.singular)) {
                     this.singular = value; // Keep one reference for serialization
                 }
             } else {
                 this.singular = value;
-                if (value != null && value.equals(this.plural))
-                 {
+                if (value != null && value.equals(this.plural)) {
                     this.plural = value; // Keep one reference for serialization
                 }
             }
@@ -203,7 +205,7 @@ public abstract class ArticledDeclension extends AbstractLanguageDeclension {
         @Override
         protected boolean validateValues(String name, LanguageCase _case) {
             if (this.singular == null) {
-                logger.info("###\tError: The noun " + name + " has no singular form");
+                logger.info(() -> "###\tError: The noun " + name + " has no singular form");
                 return false;
             }
             return true;

--- a/src/main/java/com/force/i18n/grammar/impl/SimpleDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/SimpleDeclension.java
@@ -90,8 +90,9 @@ class SimpleDeclension extends AbstractLanguageDeclension {
         protected boolean validateValues(String name, LanguageCase _case) {
 ///CLOVER:OFF
             if (this.value == null) {
-                // this is wrong.  the noun should have singular form
-                logger.severe("###\tError: The noun " + name + " has no value");
+                // this is wrong. the noun should have singular form
+                HumanLanguage language = this.getDeclension().getLanguage();
+                logger.severe(() -> "###\tError: " + language.getLocaleString() + "The noun " + name + " has no value");
                 return false;
             }
 ///CLOVER:ON


### PR DESCRIPTION
Fixed corner case If French noun has no singular form, Haitian-Creole derives no value and ends up returning `null` that may throw an exception
