### PR TITLE
fix LabelValidator to return more detail

### DIFF
--- a/src/main/java/com/force/i18n/grammar/ArticledDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/ArticledDeclension.java
@@ -132,6 +132,18 @@ public abstract class ArticledDeclension extends AbstractLanguageDeclension {
             this.value = intern(value);
         }
         @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), this.value);
+        }
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (other instanceof SimpleArticle) {
+                return super.equals(other) && Objects.equals(this.value, ((SimpleArticle)other).value);
+            }
+            return false;
+        }
+        @Override
         public boolean validate(String name) {
             if (this.value == null) {
                 HumanLanguage language = this.getDeclension().getLanguage();

--- a/src/main/java/com/force/i18n/grammar/parser/GrammaticalLabelFileParser.java
+++ b/src/main/java/com/force/i18n/grammar/parser/GrammaticalLabelFileParser.java
@@ -486,7 +486,7 @@ public class GrammaticalLabelFileParser implements BasePropertyFile.Parser {
         public String getMessage(ErrorInfo ref) {
             String ret = (ref.getArguments() == null || ref.getArguments().length == 0) ? errorMessage
                     : MessageFormat.format(errorMessage, ref.getArguments());
-            return (ref == null) ? ret : ret + " at " + ref.toString();
+            return String.format("%s at %s (%s:%d)", ret, ref.toString(), ref.file, ref.lineNumber);
         }
     }
 
@@ -511,6 +511,24 @@ public class GrammaticalLabelFileParser implements BasePropertyFile.Parser {
 
         public String getMessage() {
             return this.type.getMessage(this);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), this.type, this.file, this.lineNumber);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (other instanceof ErrorInfo) {
+                ErrorInfo o = (ErrorInfo)other;
+                return super.equals(other)
+                    && this.type == o.type
+                    && Objects.equals(this.file, o.file)
+                    && this.lineNumber == o.lineNumber;
+            }
+            return false;
         }
     }
 }

--- a/src/test/java/com/force/i18n/LocaleUtilsUnitTest.java
+++ b/src/test/java/com/force/i18n/LocaleUtilsUnitTest.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * Copyright (c) 2017, salesforce.com, inc.
  * All rights reserved.
- * Licensed under the BSD 3-Clause license. 
+ * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
  */
 
@@ -41,7 +41,17 @@ public class LocaleUtilsUnitTest extends TestCase {
     public void testGetLocaleByIsoCodeWithLanguageCountryVariant() throws Exception {
         final String isoCode = "ca_ES_PREEURO";
         final Locale actualLocale = LocaleUtils.get().getLocaleByIsoCode(isoCode);
-        assertEquals("Expected getLocaleByIsoCode to return the Catalan Spain Locale with Euro variant", 
+        assertEquals("Expected getLocaleByIsoCode to return the Catalan Spain Locale with Euro variant",
         new Locale.Builder().setLanguage("ca").setRegion("ES").setVariant("PREEURO").build(), actualLocale);
+    }
+
+    public void testGetLocaleFromHttpStrig() {
+        assertNull(LocaleUtils.get().getLocaleFromHttpInput("*"));
+        assertNull(LocaleUtils.get().getLocaleFromHttpInput(""));
+        assertNull(LocaleUtils.get().getLocaleFromHttpInput(null));
+
+        assertEquals(Locale.ENGLISH, LocaleUtils.get().getLocaleFromHttpInput("en"));
+        assertEquals(Locale.ENGLISH, LocaleUtils.get().getLocaleFromHttpInput("en;q=0.8"));
+        assertEquals(Locale.US, LocaleUtils.get().getLocaleFromHttpInput("en-US,en;q=0.8"));
     }
 }


### PR DESCRIPTION
The `LabelValidator.getInvalidLabels(HumanLanguage)` just returns collection of `LabelRef` that just tells the label key (section and param) without any context.  Add new method to return detail.

Other fix:
- add missing `hashCode()` and `equals(Object)` in `ArticleDeclension.SimpleArticle`
- simplify `LocaleUtils#getLocaleFromHttpInput(String)` with unit test
