### PR TITLE
Fix Basque noun ClassCastException and clone-aliasing on rename/override path

### DIFF
--- a/src/main/java/com/force/i18n/grammar/impl/BasqueDeclension.java
+++ b/src/main/java/com/force/i18n/grammar/impl/BasqueDeclension.java
@@ -292,7 +292,8 @@ public class BasqueDeclension extends AbstractLanguageDeclension {
      */
     public static class BasqueNoun extends Noun {
         private static final long serialVersionUID = 1L;
-        private final Map<BasqueNounForm, String> values = new EnumMap<>(BasqueNounForm.class);
+        private static final java.util.logging.Logger logger = java.util.logging.Logger.getLogger(BasqueNoun.class.getName());
+        private Map<BasqueNounForm, String> values = new EnumMap<>(BasqueNounForm.class);
         private transient volatile int stemFlags = -1;
 
         public BasqueNoun(AbstractLanguageDeclension declension, String name, String pluralAlias, NounType type,
@@ -304,6 +305,21 @@ public class BasqueDeclension extends AbstractLanguageDeclension {
         @Override
         public java.util.Map<? extends NounForm, String> getAllDefinedValues() {
             return java.util.Collections.unmodifiableMap(values);
+        }
+
+        /**
+         * Deep-copy the {@code values} map. {@link Noun#clone()} does a shallow {@code super.clone()},
+         * which would leave the clone sharing this instance's map; a subsequent {@code setString} on the
+         * clone (e.g. via the rename/override path in {@link LanguageDictionary#getDynamicNoun}) would
+         * then leak back into — and corrupt — the shared base noun. Every sibling noun with its own
+         * value map (Bengali, Bulgarian, Dravidian, Korean, Complex) overrides {@code clone()} for the
+         * same reason.
+         */
+        @Override
+        public Noun clone() {
+            BasqueNoun noun = (BasqueNoun) super.clone();
+            noun.values = new EnumMap<>(this.values);
+            return noun;
         }
 
         @Override
@@ -339,13 +355,41 @@ public class BasqueDeclension extends AbstractLanguageDeclension {
 
         @Override
         public void setString(String value, NounForm form) {
-            values.put((BasqueNounForm) form, value);
-            if (value != null) {
-                BasqueNounForm bnf = (BasqueNounForm) form;
-                if (bnf == BasqueNounForm.BASE || bnf == BasqueNounForm.SG_N_IND || bnf == BasqueNounForm.SG_N_DEF) {
-                    String lower = getDeclension().getLanguage().toFoldedCase(value);
-                    stemFlags = computeStemFlags(lower);
+            // Mirror the getString() guard: only BasqueNounForm (enum) keys are ever stored/retrieved.
+            // A dynamic (non-enum) form carries a (number, case, article) triple that has no exact enum
+            // key (e.g. a non-core singular case, or plural indefinite). Such forms flow through the
+            // rename/override path (Noun.clone(..., valueOverrides)) from the external RenamingProvider.
+            //
+            // We must not cast blindly (historically a ClassCastException), and we must not coerce the
+            // form to BASE via getExactNounForm(): that would store an already-inflected surface under
+            // the bare-stem key and corrupt render-time surface generation, which derives every form
+            // from the BASE/default string. Since getString() can never return a value for a non-enum
+            // form anyway, and Basque synthesizes such surfaces productively at render time, dropping
+            // the override loses nothing retrievable. Map to an enum key only when it round-trips.
+            BasqueNounForm bnf;
+            if (form instanceof BasqueNounForm b) {
+                bnf = b;
+            } else {
+                NounForm exact = getDeclension().getExactNounForm(form.getNumber(), form.getCase(),
+                        form.getPossessive(), form.getArticle());
+                if (exact instanceof BasqueNounForm eb
+                        && eb.getNumber() == form.getNumber()
+                        && eb.getCase() == form.getCase()
+                        && eb.getArticle() == form.getArticle()) {
+                    bnf = eb;
+                } else {
+                    if (logger.isLoggable(java.util.logging.Level.FINE)) {
+                        logger.fine("###\tIgnoring Basque noun override for non-enum form " + form.getKey()
+                                + " on " + getName() + "; rendered productively at label time.");
+                    }
+                    return;
                 }
+            }
+            values.put(bnf, value);
+            if (value != null
+                    && (bnf == BasqueNounForm.BASE || bnf == BasqueNounForm.SG_N_IND || bnf == BasqueNounForm.SG_N_DEF)) {
+                String lower = getDeclension().getLanguage().toFoldedCase(value);
+                stemFlags = computeStemFlags(lower);
             }
         }
 
@@ -625,6 +669,11 @@ public class BasqueDeclension extends AbstractLanguageDeclension {
         LanguageNumber num = (number == null) ? LanguageNumber.SINGULAR : number;
         LanguageCase kase = (languageCase == null) ? LanguageCase.NOMINATIVE : languageCase;
         LanguageArticle art = (article == null) ? getDefaultArticle() : article;
+
+        // Basque plural always uses definite morphology; normalize article for plural
+        if (num.isPlural()) {
+            art = LanguageArticle.DEFINITE;
+        }
 
         // Try exact first
         NounForm exact = getExactNounForm(num, kase, possessive, art);

--- a/src/test/java/com/force/i18n/grammar/parser/BasqueCaseRenderingTest.java
+++ b/src/test/java/com/force/i18n/grammar/parser/BasqueCaseRenderingTest.java
@@ -18,14 +18,17 @@
 package com.force.i18n.grammar.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -34,7 +37,20 @@ import org.junit.jupiter.params.provider.MethodSource;
 import com.force.i18n.HumanLanguage;
 import com.force.i18n.Renameable;
 import com.force.i18n.grammar.GrammaticalLabelSet;
+import com.force.i18n.grammar.LanguageArticle;
+import com.force.i18n.grammar.LanguageCase;
+import com.force.i18n.grammar.LanguageDeclension;
+import com.force.i18n.grammar.LanguageGender;
+import com.force.i18n.grammar.LanguageNumber;
+import com.force.i18n.grammar.LanguagePossessive;
+import com.force.i18n.grammar.LanguageStartsWith;
+import com.force.i18n.grammar.Noun;
+import com.force.i18n.grammar.Noun.NounType;
+import com.force.i18n.grammar.NounForm;
+import com.force.i18n.grammar.impl.LanguageDeclensionFactory;
 import com.force.i18n.LanguageProviderFactory;
+
+import com.google.common.collect.ImmutableMap;
 
 /**
  * End-to-end tests for Basque suffix rendering across cases and stem endings using attributes on terms. Converted to
@@ -379,6 +395,19 @@ public class BasqueCaseRenderingTest {
                             "<noun name=\"VowelH\"><value plural=\"n\">Zah</value></noun>" },
                     { "ABS pl with article=i falls back to def", "etxeak", "<house plural=\"y\" article=\"i\"/>",
                             nouns },
+
+                    // Explicit plural override: when names.xml defines both singular and plural values,
+                    // a label reference with plural="y" (default article="i") must return the stored
+                    // plural value, not the singular base + suffix.
+                    { "ABS pl explicit override (default article)", "Plural Test",
+                            "<TestXXX plural=\"y\"/>",
+                            "<noun name=\"TestXXX\"><value plural=\"n\">Singular Test</value><value plural=\"y\">Plural Test</value></noun>" },
+                    { "ABS pl explicit override (article=d)", "Plural Test",
+                            "<TestXXX plural=\"y\" article=\"d\"/>",
+                            "<noun name=\"TestXXX\"><value plural=\"n\">Singular Test</value><value plural=\"y\">Plural Test</value></noun>" },
+                    { "ABS sg explicit override still works", "Singular Test",
+                            "<TestXXX/>",
+                            "<noun name=\"TestXXX\"><value plural=\"n\">Singular Test</value><value plural=\"y\">Plural Test</value></noun>" },
                 };
             return Arrays.stream(arr).map(Arguments::of);
         }
@@ -389,7 +418,7 @@ public class BasqueCaseRenderingTest {
             assertEquals(expected, helper.renderLabel(eu, label, grammar), description);
         }
 
-        @org.junit.jupiter.api.Test
+        @Test
         void staticFallbackGenerateFromTermIfMissingReturnsNull_throws() {
             String grammar = "<noun name=\"NoVal\"></noun>";
             String label = "<NoVal case=\"d\" article=\"d\"/>";
@@ -532,6 +561,139 @@ public class BasqueCaseRenderingTest {
 
             assertEquals(expected, helper.getValue(eu, label, new Renameable[] { account, contact }, grammar),
                     description);
+        }
+    }
+
+    /**
+     * Regression tests for the rename/override write path (the runtime entry point exercised by the
+     * external {@code RenamingProvider} in the Core app server via
+     * {@link Noun#clone(LanguageGender, LanguageStartsWith, Map)}).
+     *
+     * <p>
+     * Basque's {@code getApproximateNounForm(...)} returns a non-enum {@code BasqueDynamicNounForm}
+     * whenever the requested (number, case, article) triple has no exact enum form (e.g. plural ABS
+     * with the default INDEFINITE article, or any non-core singular case). When such a form is used as
+     * an override key, it reaches {@code BasqueNoun.setString}, which historically cast the form to the
+     * enum {@code BasqueNounForm} unconditionally and threw {@link ClassCastException}.
+     * </p>
+     */
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class OverrideWritePath extends Base {
+
+        private LanguageDeclension declension() {
+            return LanguageDeclensionFactory.get().getDeclension(eu);
+        }
+
+        private Noun newBasqueNoun() {
+            // A minimal Basque noun with an explicit BASE (bare stem) override, mirroring how a
+            // dictionary-loaded noun looks before rename overrides are applied.
+            return declension().createNoun("Etxe", NounType.ENTITY, "Etxe", LanguageStartsWith.CONSONANT,
+                    LanguageGender.NEUTER,
+                    ImmutableMap.of(declension().getNounForm(LanguageNumber.SINGULAR, LanguageArticle.ZERO), "Etxe"));
+        }
+
+        /**
+         * Plural ABS with the default (INDEFINITE) article produces a dynamic form. Cloning with it as
+         * an override key drives it into setString and must not throw (was ClassCastException on 1.3.3).
+         */
+        @Test
+        void cloneWithDynamicPluralOverrideDoesNotThrow() {
+            Noun noun = newBasqueNoun();
+            NounForm dynamic = declension().getApproximateNounForm(
+                    LanguageNumber.PLURAL, LanguageCase.NOMINATIVE, LanguagePossessive.NONE, LanguageArticle.INDEFINITE);
+            Map<NounForm, String> overrides = ImmutableMap.of(dynamic, "Etxeak");
+            assertDoesNotThrow(() -> noun.clone(LanguageGender.NEUTER, LanguageStartsWith.CONSONANT, overrides),
+                    "override with a dynamic plural noun form must not throw a ClassCastException");
+        }
+
+        /**
+         * A non-core singular case (e.g. INESSIVE) has no exact singular enum form and also yields a
+         * dynamic form. Cloning with it must not throw, and — critically — must not corrupt the
+         * bare-stem BASE value used as the source for render-time surface generation.
+         */
+        @Test
+        void cloneWithDynamicNonCoreSingularDoesNotThrowOrCorruptBase() {
+            Noun noun = newBasqueNoun();
+            String baseBefore = noun.getDefaultString(false);
+
+            NounForm dynamic = declension().getApproximateNounForm(
+                    LanguageNumber.SINGULAR, LanguageCase.INESSIVE, LanguagePossessive.NONE, LanguageArticle.DEFINITE);
+            Map<NounForm, String> overrides = ImmutableMap.of(dynamic, "Etxean");
+            Noun clone = assertDoesNotThrow(
+                    () -> noun.clone(LanguageGender.NEUTER, LanguageStartsWith.CONSONANT, overrides),
+                    "override with a dynamic non-core singular noun form must not throw a ClassCastException");
+
+            // The inflected surface must NOT have overwritten the bare stem: rendering derives every
+            // form from the BASE/default string, so a corrupted base would poison all other forms.
+            assertEquals(baseBefore, clone.getDefaultString(false),
+                    "storing a dynamic (non-enum) form must not overwrite the bare-stem BASE value");
+        }
+
+        /**
+         * End-to-end analogue of the Core rename path: clone an existing dictionary noun with an
+         * override map keyed by approximate forms, exactly as {@code RenamingProvider} does.
+         */
+        @Test
+        void cloneWithApproximateFormOverridesDoesNotThrow() {
+            Noun noun = newBasqueNoun();
+            LanguageDeclension decl = declension();
+            Map<NounForm, String> overrides = ImmutableMap.of(
+                    decl.getApproximateNounForm(LanguageNumber.SINGULAR, LanguageCase.NOMINATIVE,
+                            LanguagePossessive.NONE, LanguageArticle.INDEFINITE), "Bulego",
+                    decl.getApproximateNounForm(LanguageNumber.PLURAL, LanguageCase.NOMINATIVE,
+                            LanguagePossessive.NONE, LanguageArticle.INDEFINITE), "Bulegoak");
+            assertDoesNotThrow(() -> noun.clone(LanguageGender.NEUTER, LanguageStartsWith.CONSONANT, overrides),
+                    "cloning with approximate-form override keys must not throw (Core rename path)");
+        }
+
+        /**
+         * A rename override must mutate only the clone, never the shared base dictionary noun.
+         * {@code Noun.clone()} does a shallow {@code super.clone()}, so unless {@code BasqueNoun}
+         * deep-copies its {@code values} map the clone aliases the original's storage and the override
+         * leaks back into the base (corrupting every future clone of it). This is the same guard every
+         * sibling declension (Bengali, Bulgarian, Dravidian, Korean, Complex) implements.
+         */
+        @Test
+        void cloneDoesNotMutateOriginalValues() {
+            Noun orig = newBasqueNoun();
+            // A form that actually stores (round-trips to the SG_N_DEF enum), so the leak is observable.
+            NounForm storable = declension().getNounForm(LanguageNumber.SINGULAR, LanguageArticle.DEFINITE);
+            Map<NounForm, String> overrides = ImmutableMap.of(storable, "Bulego");
+
+            orig.clone(LanguageGender.NEUTER, LanguageStartsWith.CONSONANT, overrides);
+
+            // The original must still hold only its single BASE value; the override belongs to the clone.
+            assertEquals(1, orig.getAllDefinedValues().size(),
+                    "cloning with an override must not mutate the original noun's values map (shared-map aliasing)");
+        }
+
+        /**
+         * The {@code setString} round-trip branch: a non-enum form whose (number, case, article) maps to
+         * an existing enum key must actually be stored under that enum (not dropped). Verifies the
+         * {@code bnf = eb} path, which the drop-path tests above never exercise.
+         */
+        @Test
+        void cloneWithRoundTrippingNonEnumFormStoresValue() {
+            Noun orig = newBasqueNoun();
+            // A custom (non-enum) NounForm carrying PLURAL/ERGATIVE/DEFINITE — which getExactNounForm maps
+            // to the enum PL_ERG_DEF and round-trips, so setString should store it rather than drop it.
+            NounForm nonEnum = new NounForm() {
+                @Override public LanguageNumber getNumber() { return LanguageNumber.PLURAL; }
+                @Override public LanguageCase getCase() { return LanguageCase.ERGATIVE; }
+                @Override public LanguageArticle getArticle() { return LanguageArticle.DEFINITE; }
+                @Override public LanguagePossessive getPossessive() { return LanguagePossessive.NONE; }
+                @Override public String getKey() { return "n:erg:d"; }
+            };
+            Map<NounForm, String> overrides = ImmutableMap.of(nonEnum, "Etxeek");
+
+            Noun clone = orig.clone(LanguageGender.NEUTER, LanguageStartsWith.CONSONANT, overrides);
+
+            // Retrieval is keyed by the enum, so the stored value is visible through the enum form.
+            NounForm enumForm = declension().getExactNounForm(LanguageNumber.PLURAL, LanguageCase.ERGATIVE,
+                    LanguagePossessive.NONE, LanguageArticle.DEFINITE);
+            assertEquals("Etxeek", clone.getString(enumForm),
+                    "a non-enum form that round-trips to an enum key must be stored under that enum");
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes two coupled defects in `BasqueNoun` (`BasqueDeclension.java`), both on the rename/override write path exercised via `Noun.clone(..., valueOverrides)` (the path a `RenamingProvider` drives).

### 1. `ClassCastException` in `setString`
`BasqueDeclension` uses two kinds of `NounForm`: the `BasqueNounForm` **enum** (the `EnumMap` storage key) and `BasqueDynamicNounForm`, a **non-enum** carrier produced by `getApproximateNounForm(...)` for `(number, case, article)` triples with no exact enum form. `getString` guarded against the dynamic form with `instanceof`, but `setString` cast to `BasqueNounForm` **unconditionally** — so a dynamic form reaching `setString` threw:

```
java.lang.ClassCastException: …$BasqueDynamicNounForm cannot be cast to …$BasqueNounForm
```

**Fix:** mirror the `getString` guard. Store only when the form round-trips to an exact enum key; otherwise drop the override with a `FINE` log. Coercing to `BASE` was rejected — it would store an already-inflected surface under the bare-stem key and corrupt render-time surface generation, which derives every form from the base string. Basque synthesizes those surfaces productively at render time, so a dropped override loses nothing retrievable.

### 2. Clone aliases the shared `values` map
`BasqueNoun` stored values in a member map but **did not override `clone()`**. `Noun.clone()` does a shallow `super.clone()`, so a clone shared the original's `values` map — and `setString` on the clone corrupted the base noun. This is reachable on the ordinary rename path (`LanguageDictionary.getDynamicNoun` clones then `setString`s), not just via an external provider.

**Fix:** add a `clone()` override that deep-copies the `EnumMap` (and drop `final` on `values`), matching every sibling noun with its own value map (Bengali, Bulgarian, Dravidian, Korean, Complex). Basque was the only such noun lacking the override; scalar-storage nouns (Simple, HindiUrdu, Persian, …) are inherently safe.

### 3. Plural article normalization
`getApproximateNounForm` now normalizes the plural article to `DEFINITE`, so plural ABS resolves to the exact `PL_N_DEF` enum form instead of a dynamic form.

## Tests
Adds `BasqueCaseRenderingTest.OverrideWritePath` (5 cases): CCE guard, base-not-corrupted, round-trip store branch, clone-does-not-mutate-original, and an end-to-end approximate-form override. Both defects were verified test-first (fail before the fix, pass after).

Full suite green (`mvn clean test`).