### PR TITLE
Set CODEOWNERS GUSINFO to the owning team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # Comment line immediately above ownership line is reserved for related other information. Please be careful while editing.
 #ECCN:Open Source
-#GUSINFO:Open Source,Open Source Workflow
+#GUSINFO:Globalization,Grammaticus


### PR DESCRIPTION
## What
Update the `#GUSINFO:` line in `CODEOWNERS` to reference the repository's owning team and product tag instead of the generic placeholder values.

```diff
-#GUSINFO:Open Source,Open Source Workflow
+#GUSINFO:Globalization,Grammaticus
```

## Why
The previous placeholder (`Open Source,Open Source Workflow`) is not a valid owner. This sets the correct scrum team and product tag so ownership routing resolves properly.

## Testing
Metadata-only change to `CODEOWNERS`; no code or build impact.